### PR TITLE
Replace emergency portal loader with clean build bundle

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -6,18 +6,20 @@ on:
     paths:
       - 'portal/**'
       - '_redirects'
+      - 'netlify.toml'
       - '.github/workflows/portal-smoke.yml'
   pull_request:
     paths:
       - 'portal/**'
       - '_redirects'
+      - 'netlify.toml'
       - '.github/workflows/portal-smoke.yml'
 
 permissions:
   contents: read
 
 jobs:
-  syntax-and-loader:
+  syntax-and-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,5 +37,9 @@ jobs:
             echo "Checking $f"
             node --check "$f"
           done
-      - name: Verify controlled loader repair
+      - name: Build clean portal bundle
+        run: node portal/build-app.mjs
+      - name: Check built app syntax
+        run: node --check portal/app.js
+      - name: Verify clean bundle invariants
         run: node portal/smoke-test.mjs

--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,1 @@
-/portal/app.js /portal/app-hotfix.js 200!
 /* /index.html 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "."
-  command = ""
+  command = "node portal/build-app.mjs"
 
 [[redirects]]
   from = "/*"

--- a/portal/app-ops.js
+++ b/portal/app-ops.js
@@ -1,0 +1,59 @@
+(()=>{
+'use strict';
+const SUPABASE_URL='https://ibloovohuhrceivrvhvn.supabase.co';
+const SUPABASE_KEY='sb_publishable_JtNmgzTLlepPhKDCVsn6CA_Vk7BCClv';
+let opsClient=null,opsBusy=false,lastEnhancedParticipant=null;
+function addNavLink(nav,id,num,label,href){if(!nav||document.getElementById(id))return;const a=document.createElement('a');a.id=id;a.className='nav-item';a.href=href;a.innerHTML=`<span class="nav-num">${num}</span><b>${label}</b>`;nav.appendChild(a)}
+function addMenuLink(menu,id,label,href,beforeLast=false){if(!menu||document.getElementById(id))return;const a=document.createElement('a');a.id=id;a.href=href;a.textContent=label;a.style.cssText='display:block;padding:10px 11px;border-radius:10px;color:inherit;text-decoration:none';beforeLast?menu.insertBefore(a,menu.lastElementChild):menu.insertBefore(a,menu.firstElementChild)}
+async function installOpsUi(){
+ try{
+  opsClient=opsClient||supabase.createClient(SUPABASE_URL,SUPABASE_KEY,{auth:{persistSession:true,autoRefreshToken:true,detectSessionInUrl:false}});
+  const nav=document.querySelector('#mainNav');
+  addNavLink(nav,'guideNav','00','Slik fungerer det','./guide.html');
+  addNavLink(nav,'intakeNav','02+','Interesse / VÍA','./intake.html');
+  addNavLink(nav,'ownersNav','02A','Ansvar / eiere','./owners.html');
+  addNavLink(nav,'notificationsNav','N','Varsler','./notifications.html');
+  addNavLink(nav,'auditNav','07A','Revisjon','./audit.html');
+  addNavLink(nav,'sosNav','10','Hjelp & SOS','./sos.html');
+  const menu=document.querySelector('#userMenu');
+  addMenuLink(menu,'userGuideLink','Slik fungerer reisen','./guide.html');
+  addMenuLink(menu,'userNotificationLink','Varsler','./notifications.html');
+  addMenuLink(menu,'userSosLink','Hjelp & SOS','./sos.html',true);
+  const admin=document.querySelector('#adminLink');
+  const {data:{session}}=await opsClient.auth.getSession();if(!session)return;
+  const [{data:grants},{data:own}]=await Promise.all([
+   opsClient.from('role_grants').select('role_code,revoked_at,valid_until').eq('user_id',session.user.id),
+   opsClient.from('participants').select('id').eq('user_id',session.user.id).eq('active',true).maybeSingle()
+  ]);
+  const active=(grants||[]).filter(g=>!g.revoked_at&&(!g.valid_until||new Date(g.valid_until)>new Date()));
+  const intakeRole=active.some(g=>['via_owner','program_lead'].includes(g.role_code));
+  const ownerRole=active.some(g=>['project_owner','via_owner','clinical_professional'].includes(g.role_code));
+  const isAdmin=active.some(g=>g.role_code==='system_admin');
+  document.querySelector('#intakeNav')?.classList.toggle('hidden',!intakeRole);
+  document.querySelector('#ownersNav')?.classList.toggle('hidden',!ownerRole);
+  document.querySelector('#auditNav')?.classList.toggle('hidden',!isAdmin);
+  if(admin&&!isAdmin)admin.classList.add('hidden');
+  if(own)addMenuLink(menu,'participantProfileLink','Min sikkerhetsprofil','./participant-profile.html');
+  const {count:unread}=await opsClient.from('notifications').select('id',{head:true,count:'exact'}).is('read_at',null);
+  const notif=document.querySelector('#notificationsNav');if(notif&&(unread||0)>0){const i=document.createElement('i');i.className='nav-badges';i.innerHTML=`<span class="nav-count yellow">${Math.min(unread,99)}</span>`;notif.appendChild(i)}
+  const detail=document.querySelector('#participantDetail');if(detail){const observer=new MutationObserver(()=>queueMicrotask(enhanceParticipantDetail));observer.observe(detail,{childList:true,subtree:false});await enhanceParticipantDetail()}
+ }catch(e){console.warn('[AidMe VIDA ops UI]',e)}
+}
+async function enhanceParticipantDetail(){
+ if(opsBusy||!opsClient)return;const card=document.querySelector('.participant-card.active'),detail=document.querySelector('#participantDetail');if(!card||!detail)return;const participantId=card.dataset.participantId;if(!participantId||lastEnhancedParticipant===participantId&&detail.querySelector('#workflowGateCard'))return;opsBusy=true;
+ try{
+  const {data:p,error}=await opsClient.from('participants').select('id,stage').eq('id',participantId).maybeSingle();if(error||!p)return;
+  const {data:{session}}=await opsClient.auth.getSession();if(!session)return;
+  const {data:grants}=await opsClient.from('role_grants').select('role_code,revoked_at,valid_until').eq('user_id',session.user.id);const staff=(grants||[]).some(g=>!g.revoked_at&&(!g.valid_until||new Date(g.valid_until)>new Date()));if(!staff)return;
+  let action='',label='',hint='',formKey='';
+  if(p.stage==='VIA'||p.stage==='READY_FOR_GO'){formKey='individual_go_no_go';label='Åpne individuell GO / NO-GO';hint='Formell beslutning tas i det versjonerte VÍA-skjemaet.'}
+  else if(['GO','GO_WITH_CONDITIONS'].includes(p.stage)){action='START_SER';label='Start SER';hint='Krever samlet Pilot-GO, navngitt VIDA-eier og lukkede vilkår.'}
+  else if(p.stage==='SER'){action='START_VIDA';label='Overfør til VIDA';hint='Oppretter 72t/14d/30d/90d oppfølging med navngitt VIDA-eier.'}
+  else if(p.stage==='VIDA'){action='START_NEW_VIA';label='Start ny VÍA';hint='Åpner neste veivalg uten å gjøre det automatisk.'}
+  else{lastEnhancedParticipant=participantId;return}
+  detail.querySelector('#workflowGateCard')?.remove();const box=document.createElement('div');box.id='workflowGateCard';box.className='panel-card';box.style.marginTop='14px';box.innerHTML=`<p class="eyebrow">Neste gate</p><h3>${label}</h3><p>${hint}</p><div class="form-actions"><a class="ghost" href="./owners.html?participant=${encodeURIComponent(participantId)}">Ansvar / eiere</a>${formKey?`<a class="primary" href="./form-runner.html?key=${encodeURIComponent(formKey)}&participant=${encodeURIComponent(participantId)}">${label}</a>`:`<button id="workflowGateButton" class="primary" type="button">${label}</button>`}</div><p id="workflowGateMessage" class="message"></p>`;detail.appendChild(box);lastEnhancedParticipant=participantId;
+  const btn=box.querySelector('#workflowGateButton');if(btn)btn.addEventListener('click',async()=>{btn.disabled=true;const msg=box.querySelector('#workflowGateMessage');msg.textContent='Kontrollerer gate…';const {data,error}=await opsClient.functions.invoke('workflow-command',{body:{action,participantId}});if(error||data?.error){const map={PILOT_GO_REQUIRED:'Samlet Pilot-GO mangler eller er ikke GO.',NAMED_VIDA_OWNER_REQUIRED:'Navngitt VIDA-eier mangler.',GO_CONDITIONS_OPEN:'GO-vilkår må lukkes først.',SER_REQUIRES_INDIVIDUAL_GO:'Individuell GO mangler.',FORBIDDEN:'Rollen din har ikke myndighet til denne overgangen.'};msg.textContent=map[data?.error]||'Overgangen kunne ikke gjennomføres ennå. Ingen data ble endret.';btn.disabled=false;return}msg.textContent='Overgang registrert.';lastEnhancedParticipant=null;setTimeout(()=>location.reload(),500)})
+ }finally{opsBusy=false}
+}
+setTimeout(installOpsUi,50);
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const dir=path.dirname(fileURLToPath(import.meta.url));
+const sourcePath=path.join(dir,'app-core-broken.js');
+const opsPath=path.join(dir,'app-ops.js');
+const outPath=path.join(dir,'app.js');
+let code=fs.readFileSync(sourcePath,'utf8');
+const ops=fs.readFileSync(opsPath,'utf8');
+
+function replaceOnce(label,needle,replacement){
+ const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
+}
+
+replaceOnce('task sort',
+ "const ordered=[...open].sort((a,b)=>({RED:0,YELLOW:1,GREEN:2}[severity(a)]-({RED:0,YELLOW:1,GREEN:2}[severity(b)])||new Date(a.due_at||'2999')-new Date(b.due_at||'2999'));",
+ "const rank={RED:0,YELLOW:1,GREEN:2};const ordered=[...open].sort((a,b)=>(rank[severity(a)]-rank[severity(b)])||(new Date(a.due_at||'2999')-new Date(b.due_at||'2999')));"
+);
+
+const taskRowRe=/function taskRow\(t\)\{[\s\S]*?\n\}/;
+if(!taskRowRe.test(code))throw new Error('taskRow: function missing');
+code=code.replace(taskRowRe,`function taskRow(t){
+  const p=participantById(t.participant_id),pilot=pilotById(t.pilot_id),r=routeToday(t.pilot_id),sev=severity(t);
+  const context=[p?.code_name,pilot?.route_name,r?\`Dag \${r.day_number}: \${r.from_place} → \${r.to_place}\${r.distance_km?\` · \${r.distance_km} km\`:''}\`:null].filter(Boolean).join(' · ');
+  const overdue=!!t.due_at&&['OPEN','IN_PROGRESS','WAITING'].includes(t.status)&&new Date(t.due_at)<new Date();
+  const due=overdue?\`<span class="pill RED">Forfalt · \${formatDate(t.due_at)}</span>\`:\`<span class="pill">\${formatDate(t.due_at)}</span>\`;
+  return \`<button class="task-row" data-task-id="\${t.id}"><i class="task-dot \${sev}"></i><div><b>\${escapeHtml(t.title)}</b><small>\${escapeHtml(context||t.description||'')}</small></div><div class="task-meta"><span class="pill \${sev}">\${sev==='RED'?'Kritisk':sev==='YELLOW'?'Avklar':'Normal'}</span>\${due}</div></button>\`;
+}`);
+
+const updateRe=/async function updateTaskStatus\(status\)\{[\s\S]*?\n\}/;
+if(!updateRe.test(code))throw new Error('updateTaskStatus: function missing');
+code=code.replace(updateRe,`async function updateTaskStatus(status){
+  const t=tasks.find(x=>x.id===selectedTaskId);if(!t)return;$('#taskDialogMessage').textContent='Lagrer…';
+  const {data,error}=await client.functions.invoke('task-command',{body:{taskId:t.id,status}});
+  if(error||data?.error){$('#taskDialogMessage').textContent='Kunne ikke oppdatere oppgaven med din tilgang.';return}
+  t.status=data?.task?.status||status;$('#taskDialog').close();renderAll();
+}`);
+
+const renderFormsRe=/function renderForms\(\)\{[^\n]*\}/;
+if(!renderFormsRe.test(code))throw new Error('renderForms: function missing');
+code=code.replace(renderFormsRe,`function renderForms(){const phaseFor={info_before_via:'VÍA',interest_referral:'VÍA',via_roadmap:'VÍA',individual_go_no_go:'VÍA',participant_agreement:'VÍA',pilot_go:'VÍA/SER',ser_daily:'SER',incident:'SER',vida_plan:'VIDA',pilot_evaluation:'VIDA'},participant=selectedParticipantId||ownParticipant()?.id||'';$('#formLibrary').innerHTML=formDefs.map((f,i)=>\`<a class="form-module" style="text-decoration:none;color:inherit" href="./form-runner.html?key=\${encodeURIComponent(f.key)}\${participant?'&participant='+encodeURIComponent(participant):''}"><span class="num">\${String(i).padStart(2,'0')}</span><h3>\${escapeHtml(f.title_no)}</h3><p>\${escapeHtml(f.scope==='staff'?'Arbeidsflate for navngitt rolle/ansvar.':f.scope==='participant_staff'?'Deltaker og ansvarlig medarbeider – etter tilgang.':'Deltakerrettet steg.')}</p><div class="meta"><span>\${escapeHtml(phaseFor[f.key]||'VÍA/SER/VIDA')}</span><span>Åpne →</span></div></a>\`).join('')}`);
+
+code += '\n\n/* Operational extensions are maintained separately and concatenated at build time. */\n'+ops+'\n';
+fs.writeFileSync(outPath,code,'utf8');
+console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/service-worker.js
+++ b/portal/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE='aidme-vida-shell-v3';
+const CACHE='aidme-vida-shell-v4-clean-build';
 const SHELL=['./','./index.html','./styles.css?v=20260817b','./app.js?v=20260817b','./manifest.webmanifest?v=20260817b'];
 
 self.addEventListener('install',event=>{
@@ -16,7 +16,7 @@ self.addEventListener('fetch',event=>{
   if(request.method!=='GET')return;
   const url=new URL(request.url);
   if(url.origin!==self.location.origin||url.pathname.includes('/functions/')||url.hostname.includes('supabase.co'))return;
-  event.respondWith(fetch(request).then(response=>{
+  event.respondWith(fetch(request,{cache:'no-cache'}).then(response=>{
     if(response.ok){const copy=response.clone();caches.open(CACHE).then(cache=>cache.put(request,copy));}
     return response;
   }).catch(()=>caches.match(request).then(hit=>hit||caches.match('./index.html'))));

--- a/portal/smoke-test.mjs
+++ b/portal/smoke-test.mjs
@@ -1,13 +1,12 @@
 import fs from 'node:fs';
 import vm from 'node:vm';
 
-const core=fs.readFileSync(new URL('./app-core-broken.js',import.meta.url),'utf8');
+const app=fs.readFileSync(new URL('./app.js',import.meta.url),'utf8');
 const redirects=fs.readFileSync(new URL('../_redirects',import.meta.url),'utf8');
-const bad="const ordered=[...open].sort((a,b)=>({RED:0,YELLOW:1,GREEN:2}[severity(a)]-({RED:0,YELLOW:1,GREEN:2}[severity(b)])||new Date(a.due_at||'2999')-new Date(b.due_at||'2999'));";
-const good="const rank={RED:0,YELLOW:1,GREEN:2};const ordered=[...open].sort((a,b)=>(rank[severity(a)]-rank[severity(b)])||(new Date(a.due_at||'2999')-new Date(b.due_at||'2999')));";
-
-if(!core.includes(bad))throw new Error('Portal core no longer matches the controlled loader repair. Replace the temporary loader architecture before changing this source.');
-if(!redirects.includes('/portal/app.js /portal/app-hotfix.js 200!'))throw new Error('Portal hotfix redirect is missing.');
-const repaired=core.replace(bad,good);
-new vm.Script(repaired,{filename:'portal-core-repaired.js'});
-console.log('Portal core compiles after the controlled repair, and the required redirect is present.');
+if(redirects.includes('/portal/app.js /portal/app-hotfix.js'))throw new Error('Emergency app redirect must not be present in clean-build mode.');
+if(!app.includes("client.functions.invoke('task-command'"))throw new Error('Built app is missing the secure task command path.');
+if(!app.includes('Forfalt ·'))throw new Error('Built app is missing overdue-task presentation.');
+if(!app.includes('Operational extensions are maintained separately'))throw new Error('Operational extension module was not concatenated.');
+if(app.includes('app-core-broken.js?v='))throw new Error('Built app still contains emergency runtime loader logic.');
+new vm.Script(app,{filename:'portal-app-built.js'});
+console.log('Clean portal bundle compiles, contains secure task operations and has no emergency runtime redirect.');


### PR DESCRIPTION
Removes the runtime eval/redirect hotfix from production delivery. Netlify now runs a deterministic build that repairs the legacy core source, injects secure task/form improvements and concatenates the separately maintained operational module into a normal syntax-checked `portal/app.js`. Also adds explicit overdue-task presentation and participant profile navigation. Merge only if Portal smoke and Netlify deploy-preview are green.