### PR TITLE
Portal preflight, privacy baseline and real-role QA lab

### DIFF
--- a/portal/PRIVACY_OPERATIONS_BASELINE.md
+++ b/portal/PRIVACY_OPERATIONS_BASELINE.md
@@ -1,0 +1,60 @@
+# Privacy and operations baseline before real data
+
+The canonical working draft is in SharePoint as `MY_AIDME_PRIVACY_OPERATIONS_BASELINE_2026-08-17.md`. This implementation mirror defines release gates; it is not legal sign-off.
+
+## Architecture rules
+
+- P0 public: public information; anonymous interest never writes directly to the database.
+- P1 identity: separate name/contact identity from pseudonymised program core.
+- P2 program/core: participant ID/code name, stage, pilot, route, tasks, owner and minimal status.
+- P3 sensitive program/safety: VÍA assessments, operational safety, GO, incidents and relevant check-ins; narrow role/scope + AAL2.
+- P4 healthcare/journal: if healthcare is actually delivered, journal obligations/system must be owned by the responsible healthcare entity, not silently absorbed into the AidMe program portal.
+
+## Data minimisation question before every new field
+
+1. What is the exact purpose?
+2. Who needs it to perform a written role?
+3. Can less detail or pseudonymisation achieve the purpose?
+4. How long is it needed?
+5. What event triggers deletion/anonymisation?
+6. Should the participant see/correct it?
+
+No answer = keep the field test-only/off.
+
+## P0 release gates
+
+Do not open real sensitive participant data until all are documented and approved:
+
+- DPIA / risk assessment and named controller responsibilities;
+- legal basis and transparent information per processing purpose;
+- DPA/subprocessor/data-location review;
+- approved retention matrix including backup lifecycle;
+- tested backup/restore procedure;
+- access/correction/export/deletion/restriction procedure;
+- personal-data-breach response runbook with named owners;
+- full positive/negative role and scope E2E QA;
+- Supabase leaked-password protection enabled;
+- production auth/recovery assurance.
+
+## Consent and information
+
+Do not use “consent” as a generic label for every processing activity. Keep versioned information and decisions. Image/story/marketing consent remains separate from participation.
+
+## SOS/location
+
+Current rule: participant initiates SOS and explicitly shares location for that event; location expires. No general admin remote tracking. Any future staff-triggered location feature requires a separate necessity/proportionality and DPIA decision before implementation.
+
+## Logging boundaries
+
+Operational safety facts, professional assessments and participant private reflections must remain distinguishable. Audit/security logs should contain minimal metadata and must not become a second copy of sensitive case content.
+
+## Release preflight
+
+Run in this order:
+1. `supabase/portal-health-check.sql`
+2. Supabase Security Advisor
+3. Supabase Performance Advisor
+4. Portal Smoke CI
+5. synthetic role/scope test
+6. Netlify preview
+7. only then controlled merge/deploy.

--- a/portal/ROLE_SCOPE_QA_MATRIX.md
+++ b/portal/ROLE_SCOPE_QA_MATRIX.md
@@ -1,0 +1,69 @@
+# Portal role/scope QA matrix
+
+Canonical detailed QA baseline is stored in SharePoint as `MY_AIDME_ROLE_SCOPE_QA_MATRIX_2026-08-17.md`. This file is the implementation-side mirror used during portal releases.
+
+## Source rules
+
+- Responsibility follows competence and written mandate.
+- VÍA owns clarification/preparation and must not promise SER before GO is closed.
+- SER/tour lead owns route, group, safety, incidents and simple method; it is not a treatment/diagnostic role.
+- VIDA must have a named owner and 72h + 14/30/90 follow-up.
+- System administration is not automatic professional/sensitive participant access.
+- Observer/evaluator default to aggregated learning, not individual sensitive data.
+- Healthcare/journal data belongs to the responsible healthcare entity if healthcare is actually delivered.
+
+## Current backend capabilities
+
+| Role | Capabilities |
+|---|---|
+| system_admin | manage_config, manage_roles, manage_users, view_audit |
+| project_owner | manage_program, view_case_status, view_reports |
+| program_lead | manage_intakes, manage_tasks, respond_sos, view_case_status, view_go, view_participant_core, view_ser, view_vida |
+| via_owner | decide_go, edit_via, manage_intakes, view_go, view_identity, view_operational_min, view_participant_core, view_sensitive_via |
+| clinical_professional | decide_go, edit_via, view_go, view_identity, view_incidents, view_sensitive_via |
+| ser_lead | edit_incidents, edit_ser, manage_ser_tasks, respond_sos, view_incidents, view_operational_min, view_participant_core, view_ser |
+| vida_owner | edit_vida, view_participant_core, view_vida |
+| logistics | edit_logistics, respond_sos, view_operational_min, view_participant_core |
+| observer | view_aggregated |
+| evaluator | view_aggregated |
+| break_glass | view_identity, view_incidents, view_operational_min, view_sensitive_via |
+
+Participant access is not a staff grant. It follows `participants.user_id` and own-resource RLS.
+
+## Sensitive AAL2 tables
+
+`audit_events`, `consent_events`, `form_submissions`, `go_no_go_decisions`, `incidents`, `operational_safety_profiles`, `participant_identity`, `ser_checkins`, `via_assessments`, `vida_plans` must keep `require_aal2_sensitive` as a **RESTRICTIVE** policy.
+
+## Required test pattern for every release candidate
+
+For each role use synthetic data and test:
+
+1. positive in-scope access;
+2. negative out-of-scope participant/pilot access;
+3. AAL1 denial and AAL2 success where sensitive;
+4. direct URL/API bypass denial;
+5. role-specific write succeeds only through the intended server command;
+6. audit event is written for the mutation;
+7. grant expiry/revocation takes effect;
+8. mobile navigation exposes the same allowed next action without hover-only help.
+
+Specific negative assertions:
+
+- participant never sees another participant;
+- system_admin does not gain sensitive case content from the admin role alone;
+- SER does not gain sensitive VÍA by default;
+- VIDA does not gain VÍA/incidents by default;
+- logistics cannot make professional participant decisions;
+- observer/evaluator do not gain individual sensitive data;
+- GO cannot be made by a role lacking `decide_go`;
+- break-glass must be temporary, reasoned and audited.
+
+## Context navigation acceptance rule
+
+When authorized: KPI/badge → filtered queue → task → participant/owner/pilot/route → required gate/form → updated case state.
+
+When not authorized: hide the control if awareness itself is unnecessary, otherwise show a lock + human explanation + safe next step. Mobile-critical guidance must not depend on hover.
+
+## DEMO exception
+
+`DEMO · Camino Portugués` is intentionally a mixed-stage UI lab (VÍA/SER/VIDA profiles at once). Production gate invariants must exclude `pilots.status='DEMO'`; this exception must never apply to normal pilot statuses.

--- a/portal/qa-role-pack.html
+++ b/portal/qa-role-pack.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="nb">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><meta name="robots" content="noindex,nofollow"><meta name="theme-color" content="#123f3d">
+<title>AidMe VIDA · Rolle-QA</title>
+<link rel="stylesheet" href="./styles.css"><link rel="stylesheet" href="./admin.css">
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<style>
+.qa-wrap{max-width:1180px;margin:0 auto;padding:28px}.qa-actions{display:flex;gap:10px;flex-wrap:wrap;margin:20px 0}.qa-table{width:100%;border-collapse:collapse}.qa-table th,.qa-table td{text-align:left;padding:12px;border-bottom:1px solid #ddd6c8;vertical-align:top}.qa-table code{font-size:12px;word-break:break-all}.qa-note{background:#fff8df;border:1px solid #e7d69e;border-radius:16px;padding:16px;margin:16px 0}.copy-btn{font:inherit;border:1px solid #d9d2c4;background:white;border-radius:999px;padding:6px 10px;cursor:pointer}@media(max-width:760px){.qa-wrap{padding:14px}.qa-table,.qa-table thead,.qa-table tbody,.qa-table tr,.qa-table th,.qa-table td{display:block}.qa-table thead{display:none}.qa-table tr{padding:12px 0;border-bottom:1px solid #d9d2c4}.qa-table td{border:0;padding:5px 0}.qa-table td:before{content:attr(data-label);display:block;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:#6c777a}}
+</style>
+</head>
+<body>
+<main class="qa-wrap">
+  <header class="topbar"><div><p class="eyebrow">LAB · kun syntetiske data</p><h1>Rolle- og scope-QA</h1></div><div class="top-actions"><span id="securityPill" class="security-pill">Kontrollerer…</span><a class="ghost" href="./admin.html">Administrasjon</a><a class="ghost" href="./">Portal</a></div></header>
+  <article class="preview-strip"><strong>Formål:</strong> Opprett tidsbegrensede, fiktive testkontoer slik at hver rolle kan prøves med ekte RLS – ikke bare en visuell simulering.</article>
+  <article id="blocked" class="panel-card warning-card hidden"><h2>Rolle-QA er låst</h2><p id="blockedText"></p></article>
+  <section id="workspace" class="hidden">
+    <article class="panel-card">
+      <p class="eyebrow">Syntetisk testpakke</p><h2>Test portalen som faktiske roller</h2>
+      <p>Knappen oppretter eller fornyer fiktive <code>@example.invalid</code>-kontoer. Staff-grants varer i 36 timer. Hver konto må sette opp sin egen Authenticator før sensitive AAL2-flater kan åpnes.</p>
+      <div class="qa-note"><strong>Ingen reelle data.</strong> Kontoene er kun koblet til eksisterende DEMO-deltakere/pilot. Passordene vises bare i denne responsen og lagres ikke i portalen.</div>
+      <div class="qa-actions"><button id="createPack" class="primary">Opprett / forny rollepakke</button><button id="hideCredentials" class="ghost hidden">Skjul passord</button></div>
+      <p id="message" class="message" aria-live="polite"></p>
+    </article>
+    <article id="resultCard" class="panel-card hidden">
+      <div class="card-head"><div><p class="eyebrow">Testkontoer</p><h2>Åpne privat vindu og logg inn rolle for rolle</h2></div></div>
+      <p>Test først AAL1-begrensningen, sett deretter opp MFA og test AAL2. Kontroller også at direkte URL til en forbudt modul fortsatt avvises.</p>
+      <div style="overflow:auto"><table class="qa-table"><thead><tr><th>Rolle</th><th>Scope</th><th>E-post</th><th>Midlertidig passord</th><th>Utløp</th></tr></thead><tbody id="accounts"></tbody></table></div>
+    </article>
+    <article class="panel-card"><p class="eyebrow">Testrekkefølge</p><h2>Positiv + negativ tilgang</h2><ol><li>Logg inn som rollen og se hva som faktisk vises.</li><li>Forsøk riktig in-scope deltaker/pilot.</li><li>Forsøk en out-of-scope deltaker eller direkte URL.</li><li>Test før og etter MFA.</li><li>Følg KPI → kø → oppgave → deltaker → gate/skjema → tilbake.</li><li>Noter alt som føles ulogisk selv om sikkerheten teknisk er korrekt.</li></ol></article>
+  </section>
+</main>
+<script src="./qa-role-pack.js"></script>
+</body></html>

--- a/portal/qa-role-pack.js
+++ b/portal/qa-role-pack.js
@@ -1,0 +1,22 @@
+const SUPABASE_URL='https://ibloovohuhrceivrvhvn.supabase.co';
+const SUPABASE_PUBLISHABLE_KEY='sb_publishable_JtNmgzTLlepPhKDCVsn6CA_Vk7BCClv';
+const client=supabase.createClient(SUPABASE_URL,SUPABASE_PUBLISHABLE_KEY);
+const $=s=>document.querySelector(s);
+function activeGrant(g){const now=new Date();return !g.revoked_at&&(!g.valid_from||new Date(g.valid_from)<=now)&&(!g.valid_until||new Date(g.valid_until)>now)}
+function esc(v=''){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+async function boot(){
+ const {data:{session}}=await client.auth.getSession();if(!session){block('Logg inn i portalen først.');return}
+ const {data:assurance}=await client.auth.mfa.getAuthenticatorAssuranceLevel();const aal2=assurance?.currentLevel==='aal2';$('#securityPill').textContent=aal2?'AAL2 · bekreftet':'AAL1 · MFA kreves';$('#securityPill').classList.toggle('secure',aal2);
+ if(!aal2){block('Bekreft Authenticator/AAL2 i portalens Sikkerhet før testkontoer kan opprettes.');return}
+ const {data:grants,error}=await client.from('role_grants').select('role_code,valid_from,valid_until,revoked_at');if(error){block('Kunne ikke kontrollere rolle.');return}
+ if(!(grants||[]).some(g=>activeGrant(g)&&g.role_code==='system_admin')){block('Denne siden krever aktiv systemadministratorrolle.');return}
+ $('#workspace').classList.remove('hidden');
+}
+function block(text){$('#blockedText').textContent=text;$('#blocked').classList.remove('hidden')}
+function renderAccounts(rows){$('#accounts').innerHTML=(rows||[]).map(a=>`<tr><td data-label="Rolle"><strong>${esc(a.label)}</strong></td><td data-label="Scope"><code>${esc(a.scope)}</code></td><td data-label="E-post"><code>${esc(a.email)}</code> <button class="copy-btn" data-copy="${esc(a.email)}">Kopier</button></td><td data-label="Midlertidig passord"><code class="secret">${esc(a.password)}</code> <button class="copy-btn" data-copy="${esc(a.password)}">Kopier</button></td><td data-label="Utløp">${a.expiresAt?new Date(a.expiresAt).toLocaleString('nb-NO'):'Deltaker-demo'}</td></tr>`).join('');
+ $('#resultCard').classList.remove('hidden');$('#hideCredentials').classList.remove('hidden');
+ document.querySelectorAll('[data-copy]').forEach(b=>b.addEventListener('click',async()=>{await navigator.clipboard.writeText(b.dataset.copy||'');const old=b.textContent;b.textContent='Kopiert';setTimeout(()=>b.textContent=old,900)}));
+}
+$('#createPack').addEventListener('click',async()=>{const btn=$('#createPack');btn.disabled=true;$('#message').textContent='Oppretter syntetiske testkontoer…';const {data,error}=await client.functions.invoke('qa-create-role-pack',{body:{}});btn.disabled=false;if(error||data?.error){$('#message').textContent='Kunne ikke opprette rollepakken. Kontroller AAL2 og systemadministratorrollen.';return}$('#message').textContent=`Rollepakken er klar. Staff-tilgang utløper ${new Date(data.expiresAt).toLocaleString('nb-NO')}.`;renderAccounts(data.accounts)});
+$('#hideCredentials').addEventListener('click',()=>{document.querySelectorAll('.secret').forEach(x=>x.textContent='••••••••••••');$('#hideCredentials').classList.add('hidden')});
+boot();

--- a/supabase/functions/qa-create-role-pack/index.ts
+++ b/supabase/functions/qa-create-role-pack/index.ts
@@ -1,0 +1,57 @@
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+const allowedOrigins=new Set(['https://my.aidme.no','https://main--mycamino.netlify.app','http://localhost:8888','http://localhost:3000']);
+function headers(req:Request){const o=req.headers.get('origin')??'';return {'Access-Control-Allow-Origin':allowedOrigins.has(o)?o:'https://my.aidme.no','Access-Control-Allow-Headers':'authorization, x-client-info, apikey, content-type','Access-Control-Allow-Methods':'POST, OPTIONS','Content-Type':'application/json','Cache-Control':'no-store','Vary':'Origin'}}
+function claims(token:string){try{const p=token.split('.')[1];const n=p.replace(/-/g,'+').replace(/_/g,'/');return JSON.parse(atob(n+'='.repeat((4-n.length%4)%4)))}catch{return{}}}
+function makePassword(){const alphabet='ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%';const bytes=new Uint8Array(24);crypto.getRandomValues(bytes);return [...bytes].map(b=>alphabet[b%alphabet.length]).join('')}
+
+Deno.serve(async(req:Request)=>{
+ const h=headers(req);if(req.method==='OPTIONS')return new Response('ok',{headers:h});if(req.method!=='POST')return new Response(JSON.stringify({error:'METHOD_NOT_ALLOWED'}),{status:405,headers:h});
+ try{
+  const auth=req.headers.get('Authorization')??'';const token=auth.replace(/^Bearer\s+/i,'');if(!token)return new Response(JSON.stringify({error:'UNAUTHORIZED'}),{status:401,headers:h});
+  if((claims(token) as any).aal!=='aal2')return new Response(JSON.stringify({error:'MFA_REQUIRED'}),{status:403,headers:h});
+  const pub=JSON.parse(Deno.env.get('SUPABASE_PUBLISHABLE_KEYS')??'{}').default;const secret=JSON.parse(Deno.env.get('SUPABASE_SECRET_KEYS')??'{}').default;
+  const userClient=createClient(Deno.env.get('SUPABASE_URL')!,pub,{global:{headers:{Authorization:auth}},auth:{persistSession:false}});
+  const admin=createClient(Deno.env.get('SUPABASE_URL')!,secret,{auth:{persistSession:false}});
+  const {data:u,error:ue}=await userClient.auth.getUser(token);if(ue||!u.user)return new Response(JSON.stringify({error:'UNAUTHORIZED'}),{status:401,headers:h});
+  const now=new Date();const nowIso=now.toISOString();
+  const {data:grants,error:ge}=await admin.from('role_grants').select('role_code,valid_from,valid_until,revoked_at').eq('user_id',u.user.id);if(ge)throw ge;
+  const active=(grants??[]).filter((g:any)=>!g.revoked_at&&(!g.valid_from||g.valid_from<=nowIso)&&(!g.valid_until||g.valid_until>nowIso)).map((g:any)=>g.role_code);
+  if(!active.includes('system_admin'))return new Response(JSON.stringify({error:'FORBIDDEN'}),{status:403,headers:h});
+  const {data:org,error:oe}=await admin.from('organizations').select('id').eq('name','AidMe VIDA').limit(1).maybeSingle();if(oe||!org)throw oe??new Error('ORG_NOT_FOUND');
+  const {data:pilot,error:pe}=await admin.from('pilots').select('id').eq('organization_id',org.id).eq('status','DEMO').limit(1).maybeSingle();if(pe||!pilot)throw pe??new Error('DEMO_PILOT_NOT_FOUND');
+  const {data:parts,error:pae}=await admin.from('participants').select('id,code_name,user_id').eq('organization_id',org.id).in('code_name',['DEMO-VIA-01','DEMO-SER-02','DEMO-VIDA-03']);if(pae)throw pae;
+  const byCode=Object.fromEntries((parts??[]).map((p:any)=>[p.code_name,p]));if(!byCode['DEMO-VIA-01']||!byCode['DEMO-VIDA-03'])throw new Error('DEMO_PARTICIPANTS_NOT_FOUND');
+  const specs=[
+   {key:'participant',email:'qa-participant@example.invalid',name:'QA Deltaker',role:null,participant:'DEMO-VIA-01',pilot:null,title:'Deltaker'},
+   {key:'via_owner',email:'qa-via@example.invalid',name:'QA VÍA',role:'via_owner',participant:'DEMO-VIA-01',pilot:null,title:'VÍA-ansvarlig'},
+   {key:'clinical_professional',email:'qa-fag@example.invalid',name:'QA Fagperson',role:'clinical_professional',participant:'DEMO-VIA-01',pilot:null,title:'Relevant fagperson'},
+   {key:'ser_lead',email:'qa-ser@example.invalid',name:'QA SER',role:'ser_lead',participant:null,pilot:pilot.id,title:'SER-/turleder'},
+   {key:'vida_owner',email:'qa-vida@example.invalid',name:'QA VIDA',role:'vida_owner',participant:'DEMO-VIDA-03',pilot:null,title:'VIDA-eier'},
+   {key:'logistics',email:'qa-logistics@example.invalid',name:'QA Logistikk',role:'logistics',participant:null,pilot:pilot.id,title:'Logistikk / beredskap'},
+   {key:'program_lead',email:'qa-program@example.invalid',name:'QA Programleder',role:'program_lead',participant:null,pilot:pilot.id,title:'Programleder'},
+   {key:'project_owner',email:'qa-project@example.invalid',name:'QA Prosjekteier',role:'project_owner',participant:null,pilot:null,title:'Prosjekteier'},
+   {key:'observer',email:'qa-observer@example.invalid',name:'QA Observatør',role:'observer',participant:null,pilot:pilot.id,title:'Observatør'},
+   {key:'evaluator',email:'qa-evaluator@example.invalid',name:'QA Evaluator',role:'evaluator',participant:null,pilot:pilot.id,title:'Evaluator'}
+  ];
+  const {data:list,error:le}=await admin.auth.admin.listUsers({page:1,perPage:1000});if(le)throw le;const existing=new Map((list.users??[]).map((x:any)=>[String(x.email).toLowerCase(),x]));
+  const expires=new Date(now.getTime()+36*60*60*1000).toISOString();const result:any[]=[];
+  for(const s of specs){
+   const password=makePassword();let user:any=existing.get(s.email.toLowerCase());
+   if(user){const {data:upd,error}=await admin.auth.admin.updateUserById(user.id,{password,email_confirm:true,user_metadata:{qa_role_pack:true,qa_key:s.key}});if(error)throw error;user=upd.user}
+   else {const {data:cre,error}=await admin.auth.admin.createUser({email:s.email,password,email_confirm:true,user_metadata:{qa_role_pack:true,qa_key:s.key}});if(error)throw error;user=cre.user;existing.set(s.email.toLowerCase(),user)}
+   const {error:pre}=await admin.from('profiles').upsert({user_id:user.id,display_name:s.name,locale:'nb',active:true},{onConflict:'user_id'});if(pre)throw pre;
+   if(s.role){
+    const {error:sp}=await admin.from('staff_profiles').upsert({user_id:user.id,full_name:s.name,job_title:s.title,work_email:s.email,organization_id:org.id,active:true},{onConflict:'user_id'});if(sp)throw sp;
+    const {error:rv}=await admin.from('role_grants').update({revoked_at:nowIso}).eq('user_id',user.id).eq('reason','SYNTHETIC_QA_ROLE_PACK').is('revoked_at',null);if(rv)throw rv;
+    const {error:ri}=await admin.from('role_grants').insert({organization_id:org.id,user_id:user.id,role_code:s.role,participant_id:s.participant?byCode[s.participant].id:null,pilot_id:s.pilot,reason:'SYNTHETIC_QA_ROLE_PACK',valid_from:nowIso,valid_until:expires,granted_by:u.user.id});if(ri)throw ri;
+   } else {
+    const p=byCode[s.participant];if(p.user_id&&p.user_id!==user.id)throw new Error('DEMO_PARTICIPANT_ALREADY_MAPPED');
+    const {error:pu}=await admin.from('participants').update({user_id:user.id,updated_at:nowIso}).eq('id',p.id);if(pu)throw pu;
+   }
+   result.push({key:s.key,label:s.title,email:s.email,password,expiresAt:s.role?expires:null,scope:s.participant?`participant:${s.participant}`:s.pilot?'pilot:DEMO':'organization:AidMe VIDA'});
+  }
+  await admin.from('audit_events').insert({organization_id:org.id,actor_user_id:u.user.id,action:'QA_ROLE_PACK_CREATED',resource_type:'qa_role_pack',purpose:'Synthetic role/scope E2E QA',metadata:{roles:specs.map(s=>s.key),expires_at:expires}});
+  return new Response(JSON.stringify({ok:true,synthetic:true,warning:'DEMO-NOT-REAL-DATA',expiresAt:expires,accounts:result}),{status:201,headers:h});
+ }catch(e){console.error(e);return new Response(JSON.stringify({error:'QA_ROLE_PACK_FAILED'}),{status:500,headers:h})}
+})

--- a/supabase/portal-health-check.sql
+++ b/supabase/portal-health-check.sql
@@ -1,0 +1,76 @@
+-- AidMe VIDA portal pre-release health checks
+-- Safe read-only queries. Run before release/checkpoint against the target Supabase project.
+
+-- 1) Core invariant summary: all values should be 0.
+select
+  (select count(*) from public.form_definitions fd where not exists (
+    select 1 from public.form_versions fv
+    where fv.form_definition_id=fd.id
+      and fv.published_at is not null
+      and (fv.retired_at is null or fv.retired_at>now())
+  )) as forms_without_active_version,
+  (select count(*) from public.role_grants rg
+    where rg.revoked_at is null and rg.valid_until is not null and rg.valid_until<=now()) as unrevoked_expired_grants,
+  (select count(*) from public.role_grants rg join public.participants p on p.id=rg.participant_id
+    where rg.revoked_at is null and rg.organization_id<>p.organization_id) as participant_scope_org_mismatches,
+  (select count(*) from public.role_grants rg join public.pilots pi on pi.id=rg.pilot_id
+    where rg.revoked_at is null and rg.organization_id<>pi.organization_id) as pilot_scope_org_mismatches,
+  (select count(*) from public.pilot_participants pp
+    join public.participants p on p.id=pp.participant_id
+    join public.pilots pi on pi.id=pp.pilot_id
+    where pp.status='ACTIVE' and p.organization_id<>pi.organization_id) as participant_pilot_org_mismatches,
+  (select count(*) from public.tasks t
+    where t.status in ('OPEN','IN_PROGRESS','WAITING')
+      and (t.severity='RED' or t.priority=1) and t.assignee_user_id is null) as critical_open_tasks_without_owner,
+  (select count(*) from public.tasks t
+    where t.status in ('OPEN','IN_PROGRESS','WAITING')
+      and (t.severity='RED' or t.priority=1) and t.due_at is null) as critical_open_tasks_without_due,
+  (select count(*) from public.sos_events s
+    where s.status in ('OPEN','ACKNOWLEDGED')
+      and (s.participant_id is null or s.initiated_by is null)) as open_sos_missing_core_context,
+  (select count(*) from public.sos_location_snapshots l where l.expires_at<=now()) as expired_sos_locations_remaining,
+  (select count(*) from public.role_onboarding_items i
+    where i.required and i.status<>'DONE'
+      and exists(select 1 from public.role_grants rg where rg.id=i.role_grant_id
+        and (rg.revoked_at is not null or (rg.valid_until is not null and rg.valid_until<=now())))) as onboarding_open_for_inactive_grant;
+
+-- 2) AAL2 must be RESTRICTIVE on every sensitive table listed here.
+select tablename, policyname, permissive, cmd
+from pg_policies
+where schemaname='public' and policyname='require_aal2_sensitive'
+order by tablename;
+
+-- Expected sensitive table set:
+-- audit_events, consent_events, form_submissions, go_no_go_decisions, incidents,
+-- operational_safety_profiles, participant_identity, ser_checkins, via_assessments, vida_plans.
+-- Every row must report permissive = RESTRICTIVE.
+
+-- 3) Production-pilot gate check. DEMO pilots are intentionally excluded because the mixed-stage
+-- demo collection is a UI laboratory, not a real cohort.
+with active_pilot as (
+  select pp.participant_id, pp.pilot_id
+  from public.pilot_participants pp
+  join public.pilots pi on pi.id=pp.pilot_id
+  where pp.status='ACTIVE' and pi.status<>'DEMO'
+), latest_go as (
+  select distinct on (participant_id) participant_id, decision, decided_at
+  from public.go_no_go_decisions
+  order by participant_id, decided_at desc
+), latest_via as (
+  select distinct on (participant_id) participant_id, vida_owner_user_id, updated_at
+  from public.via_assessments
+  order by participant_id, updated_at desc
+)
+select p.code_name,p.stage::text as stage,pi.name as pilot,
+       lg.decision::text as latest_individual_go,
+       (lv.vida_owner_user_id is not null) as has_named_vida_owner
+from public.participants p
+join active_pilot ap on ap.participant_id=p.id
+join public.pilots pi on pi.id=ap.pilot_id
+left join latest_go lg on lg.participant_id=p.id
+left join latest_via lv on lv.participant_id=p.id
+where p.active and (
+  (p.stage in ('GO','GO_WITH_CONDITIONS','SER','VIDA','NEW_VIA') and lg.participant_id is null)
+  or (p.stage in ('GO','GO_WITH_CONDITIONS','SER','VIDA','NEW_VIA') and lv.vida_owner_user_id is null)
+)
+order by pi.name,p.code_name;


### PR DESCRIPTION
Autonomous hardening block before tomorrow's owner UX round.

Includes:
- source-grounded role/scope QA matrix;
- privacy/operations real-data production gate;
- repeatable read-only Supabase health/invariant SQL;
- protected `qa-create-role-pack` Edge Function source (already deployed v1 to the beta project, verify_jwt=true, AAL2 + system_admin required);
- system-admin QA lab page that creates/renews synthetic `@example.invalid` role accounts with real RLS scopes for participant, VÍA, fagperson, SER, VIDA, logistics, program lead, project owner, observer and evaluator.

Staff QA grants expire after 36h; all data remain synthetic. No public intake or real sensitive data is opened by this PR.