### PR TITLE
Mobile parity: auto-hide portal nav

### DIFF
--- a/portal/app-mobile.js
+++ b/portal/app-mobile.js
@@ -1,0 +1,67 @@
+(()=>{
+'use strict';
+
+const MOBILE_UX_VERSION='2026-08-18a';
+const MOBILE_BREAKPOINT=780;
+const COLLAPSE_AFTER=84;
+const RESTORE_AT=20;
+
+function addMobileStyles(){
+  if(document.querySelector('link[data-aidme-mobile]'))return;
+  const link=document.createElement('link');
+  link.rel='stylesheet';
+  link.href=`./mobile.css?v=${MOBILE_UX_VERSION}`;
+  link.dataset.aidmeMobile='1';
+  document.head.appendChild(link);
+}
+
+function installMobileNavAutoHide(){
+  const sidebar=document.querySelector('.sidebar');
+  if(!sidebar||sidebar.dataset.mobileAutoHide)return;
+  sidebar.dataset.mobileAutoHide='1';
+
+  let ticking=false;
+  const apply=()=>{
+    ticking=false;
+    if(window.innerWidth>MOBILE_BREAKPOINT){
+      sidebar.classList.remove('mobile-nav-hidden');
+      sidebar.removeAttribute('aria-hidden');
+      return;
+    }
+
+    const y=Math.max(0,window.scrollY||document.documentElement.scrollTop||0);
+    const focusInside=sidebar.contains(document.activeElement);
+    if(y<=RESTORE_AT||focusInside){
+      sidebar.classList.remove('mobile-nav-hidden');
+      sidebar.removeAttribute('aria-hidden');
+    }else if(y>=COLLAPSE_AFTER){
+      sidebar.classList.add('mobile-nav-hidden');
+      sidebar.setAttribute('aria-hidden','true');
+    }
+  };
+
+  const schedule=()=>{
+    if(ticking)return;
+    ticking=true;
+    requestAnimationFrame(apply);
+  };
+
+  window.addEventListener('scroll',schedule,{passive:true});
+  window.addEventListener('resize',schedule,{passive:true});
+  window.addEventListener('pageshow',schedule);
+  sidebar.addEventListener('focusin',schedule);
+
+  // View changes normally return to the top; make the navigation visible immediately.
+  document.querySelector('#mainNav')?.addEventListener('click',()=>{
+    if(window.innerWidth<=MOBILE_BREAKPOINT){
+      sidebar.classList.remove('mobile-nav-hidden');
+      sidebar.removeAttribute('aria-hidden');
+    }
+  });
+
+  apply();
+}
+
+addMobileStyles();
+installMobileNavAutoHide();
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -7,11 +7,13 @@ const sourcePath=path.join(dir,'app-core-broken.js');
 const opsPath=path.join(dir,'app-ops.js');
 const uxPath=path.join(dir,'app-ux.js');
 const onboardingPath=path.join(dir,'app-onboarding.js');
+const mobilePath=path.join(dir,'app-mobile.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
 const ux=fs.readFileSync(uxPath,'utf8');
 const onboarding=fs.readFileSync(onboardingPath,'utf8');
+const mobile=fs.readFileSync(mobilePath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -52,6 +54,7 @@ code=code.replace(renderFormsRe,`function renderForms(){const phaseFor={info_bef
 
 code += '\n\n/* Operational extensions are maintained separately and concatenated at build time. */\n'+ops+'\n';
 code += '\n\n/* UX/auth/mobile hardening is maintained separately and concatenated after operations. */\n'+ux+'\n';
-code += '\n\n/* Role onboarding navigation is maintained separately and concatenated last. */\n'+onboarding+'\n';
+code += '\n\n/* Role onboarding navigation is maintained separately. */\n'+onboarding+'\n';
+code += '\n\n/* Mobile parity and navigation behavior are maintained separately and concatenated last. */\n'+mobile+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/mobile.css
+++ b/portal/mobile.css
@@ -1,0 +1,20 @@
+/* AidMe VIDA – mobile parity additions. Loaded after ux.css. */
+@media(max-width:780px){
+  .sidebar{
+    transition:transform .2s ease,opacity .16s ease,box-shadow .16s ease;
+    will-change:transform;
+  }
+  .sidebar.mobile-nav-hidden{
+    transform:translateY(calc(-100% - env(safe-area-inset-top,0px)));
+    opacity:0;
+    pointer-events:none;
+    box-shadow:none;
+  }
+  .sidebar.mobile-nav-hidden + .workspace{
+    /* Sticky sidebar leaves normal document flow behind at the top only; once scrolled,
+       translating it away frees the reading viewport without a layout jump. */
+  }
+}
+@media(prefers-reduced-motion:reduce){
+  .sidebar{transition:none!important}
+}


### PR DESCRIPTION
Mobile UX parity follow-up from owner QA. Adds an isolated mobile module that hides the large portal navigation once the user scrolls past the top, restores it at the top/focus, respects reduced motion, and keeps desktop unchanged. Built through the existing deterministic portal build pipeline.