### PR TITLE
N3: participant-first VÍA portal experience

### DIFF
--- a/portal/END_TO_END_ROLE_JOURNEY.md
+++ b/portal/END_TO_END_ROLE_JOURNEY.md
@@ -20,7 +20,7 @@ Status: operativ implementerings- og QA-referanse. Faglig autoritet ligger i akt
 |---|---|---|---|---|---|
 | 0. Offentlig interesse | Potensiell deltaker | `Se om dette kan passe for meg` → kort interesse | `info_before_via` / Skjema 00 som informasjonsgrunnlag; `interest_referral` / Skjema 01 når interesse registreres | Mottak/program | Bare dataminimal kontakt og formål. Ingen detaljert helse-/risikokartlegging offentlig. |
 | 1. Mottak/triage | Programleder / VÍA-mottak | Trenger avklaring / Gå videre til VÍA / Anbefal annen vei / Avslutt | `interest_referral` | `manage_intakes` | Interesse ≠ godkjenning. Ikke opprett konto før personen faktisk skal inn i VÍA. |
-| 2. VÍA-start | Deltaker + VÍA-eier | Sikker invitasjon → `Din neste handling` | `info_before_via`, `interest_referral`, `via_roadmap` | VÍA-eier | Egenressurs for deltaker; staff kun innen rolle+scope. Sensitive VÍA-data krever AAL2. |
+| 2. VÍA-start | Deltaker + VÍA-eier | Opprett VÍA én gang → sikker invitasjon kobles til samme reise → `Din neste handling` | `info_before_via`, `interest_referral`, `via_roadmap` | VÍA-eier | Egenressurs for deltaker; staff kun innen rolle+scope. Sensitive VÍA-data krever AAL2. |
 | 3. VÍA-avklaring | Deltaker + VÍA-eier + relevant fagperson | Fyll mangler i små steg → avklaring | `via_roadmap` / Skjema 02 | VÍA-eier | Deltaker kan korrigere egne opplysninger. Intern vurdering skilles fra deltakertekst. |
 | 4. Individuell beslutning | VÍA-eier / relevant fagperson | GO / GO med vilkår / UTSETT / NO-GO nå | `individual_go_no_go` / Skjema 03 | `decide_go` | Ikke scorekort. Vilkår blir oppgaver med eier/frister. Deltakersammendrag skilles fra intern begrunnelse. |
 | 5. Før SER | Deltaker + program/logistikk | Avtale, kontaktvalg, dokumenter, forsikring, VIDA-eier, praktisk beredskap | `participant_agreement` / Skjema 04 + `pilot_go` / Skjema 05 | Program/pilot-GO | Samlet SER/pilot-GO er egen gate etter individuell beslutning. |
@@ -117,7 +117,7 @@ Mini CRM kan inneholde relasjonsminne om partner, finansiør, offentlig/NAV/komm
 
 ## P0/P1 før ekte persondata åpnes bredere
 
-1. `portal/intake.js` bruker Edge Function `intake-command`, men kildekoden er per 2026-08-21 ikke funnet under `supabase/functions/` i Git. Live-kilde/deploy må bringes under gjenopprettbar kontroll før backend endres.
+1. **LUKKET 2026-08-22:** `intake-command` er gjenopprettet fra aktiv Supabase-deploy til `supabase/functions/intake-command/` i Git og er igjen under gjenopprettbar kildekontroll. N2→N3-kjeden har i tillegg fått versjonskontrollert `admin-create-participant`. En bredere Supabase↔Git source-parity-audit gjenstår som teknisk hygiene, men blokkerer ikke denne brukerreisen.
 2. `form-runner.js` skriver i dag til `form_submissions` fra nettleserklienten. Selv med RLS/AAL2 må dette eksplisitt verifiseres mot regelen om autoriserte serverkommandoer, audit og minst mulig write-surface før ekte sensitive skjema åpnes.
 3. Offentlig `public-intake` forblir fail-closed til CAPTCHA/Turnstile, rate-limit, origin, personverntekst og dataminimering er verifisert samlet.
 4. Alle sensitive rollebaner skal gjennom positiv + negativ scope-test, AAL1/AAL2, direkte URL/API-bypass, audit og utløp/tilbakekalling.

--- a/portal/app-participant.js
+++ b/portal/app-participant.js
@@ -1,0 +1,100 @@
+(()=>{
+'use strict';
+
+function participantStageCopy(stage){
+  const s=stageLabel(stage);
+  if(s==='SER')return'Under · erfaring, rytme og trygg tilpasning';
+  if(s==='VIDA')return'Etter · erfaring omsettes til handling hjemme';
+  if(s==='ny VÍA')return'Neste retning · ny avklaring når du er klar';
+  return'Før · retning, avklaring og forberedelse';
+}
+function participantOpenTasks(p){return tasks.filter(t=>t.participant_id===p?.id&&['OPEN','IN_PROGRESS','WAITING'].includes(t.status))}
+function participantTaskTone(t){const s=severity(t);return s==='RED'?'Viktig':s==='YELLOW'?'Avklares':'Neste steg'}
+function participantFormKeys(stage){
+  const s=stageLabel(stage);
+  if(s==='SER')return new Set(['ser_daily','participant_agreement']);
+  if(s==='VIDA')return new Set(['vida_plan']);
+  if(s==='ny VÍA')return new Set(['via_roadmap']);
+  return new Set(['info_before_via','via_roadmap','participant_agreement']);
+}
+
+const staffTaskRow=taskRow;
+taskRow=function(t){
+  if(isStaff())return staffTaskRow(t);
+  const p=participantById(t.participant_id),pilot=pilotById(t.pilot_id),r=routeToday(t.pilot_id),sev=severity(t),overdue=!!t.due_at&&['OPEN','IN_PROGRESS','WAITING'].includes(t.status)&&new Date(t.due_at)<new Date();
+  const context=[r?`Dag ${r.day_number}: ${r.from_place} → ${r.to_place}${r.distance_km?` · ${r.distance_km} km`:''}`:null,t.description||null].filter(Boolean).join(' · ');
+  const due=overdue?`<span class="pill RED">Frist passert · ${formatDate(t.due_at)}</span>`:`<span class="pill">${formatDate(t.due_at)}</span>`;
+  return `<button class="task-row" data-task-id="${t.id}"><i class="task-dot ${sev}"></i><div><b>${escapeHtml(t.title)}</b><small>${escapeHtml(context)}</small></div><div class="task-meta"><span class="pill ${sev}">${participantTaskTone(t)}</span>${due}</div></button>`;
+};
+
+const staffRenderPulse=renderPulse;
+renderPulse=function(){
+  if(isStaff())return staffRenderPulse();
+  const p=ownParticipant();if(!p){$('#groupPulse').innerHTML='<p>Reisen din er ikke aktivert ennå.</p>';return}
+  const l=latestCheckin(p.id),open=participantOpenTasks(p),phase=stageLabel(p.stage);
+  $('#groupPulse').innerHTML=`<div class="pulse-row"><i class="dot ${phase==='SER'?'ser':phase==='VIDA'?'vida':'via'}"></i><div><b>${escapeHtml(phase)} · din reise</b><small>${l?.checkin_date?`Sist innsjekk ${escapeHtml(l.checkin_date)}`:'Ingen innsjekk ennå'}</small></div><small>${open.length} åpne steg</small></div>`;
+};
+
+const staffRenderParticipants=renderParticipants;
+renderParticipants=function(){
+  if(isStaff())return staffRenderParticipants();
+  const p=ownParticipant();$('#participantsNavLabel').textContent='Min reise';$('#participantsHeading').textContent='Min reise';$('#participantsIntro').textContent='Fase, neste handling og det som er relevant for deg – uten interne arbeidsmarkører.';
+  selectedParticipantId=p?.id||null;
+  if(!p){$('#participantList').innerHTML='<p>Ingen aktiv reise ennå.</p>';$('#participantDetail').innerHTML='<h3>Reisen din er ikke aktivert ennå</h3><p>Kontakt AidMe-kontakten din dersom du forventet tilgang.</p>';fillParticipantSelect();return}
+  const phase=stageLabel(p.stage),open=participantOpenTasks(p);
+  $('#participantList').innerHTML=`<button class="participant-card active" data-participant-id="${p.id}"><i class="dot ${phase==='SER'?'ser':phase==='VIDA'?'vida':'via'}"></i><div><b>${escapeHtml(p.code_name)}</b><small>${escapeHtml(phase)} · ${open.length} åpne steg</small></div><span class="pill">${escapeHtml(phase)}</span></button>`;
+  renderParticipantDetail();fillParticipantSelect();
+};
+
+const staffRenderParticipantDetail=renderParticipantDetail;
+renderParticipantDetail=function(){
+  if(isStaff())return staffRenderParticipantDetail();
+  const p=ownParticipant();if(!p){$('#participantDetail').innerHTML='<h3>Ingen aktiv reise ennå</h3>';return}
+  const phase=stageLabel(p.stage),pilot=participantPilot(p.id),r=routeToday(pilot?.id),open=participantOpenTasks(p),ordered=[...open].sort((a,b)=>new Date(a.due_at||'2999')-new Date(b.due_at||'2999')),next=ordered[0],idx=stageIndex(p.stage);
+  $('#participantDetail').innerHTML=`<div class="card-head"><div><p class="eyebrow">${escapeHtml(phase)} · din reise</p><h2>${escapeHtml(p.code_name)}</h2></div><span class="pill">${escapeHtml(phase)}</span></div><p>${escapeHtml(participantStageCopy(p.stage))}</p><div class="detail-grid"><div class="detail-stat"><span>Fase</span><strong>${escapeHtml(phase)}</strong></div><div class="detail-stat"><span>Neste frist</span><strong>${escapeHtml(next?formatDate(next.due_at):'Ingen frist')}</strong></div><div class="detail-stat"><span>Åpne steg</span><strong>${open.length}</strong></div><div class="detail-stat"><span>${phase==='SER'?'Dagens etappe':'Gruppe / rute'}</span><strong>${escapeHtml(phase==='SER'&&r?`${r.from_place} → ${r.to_place}`:(pilot?.route_name||'Avklares senere'))}</strong></div></div><h3>Din neste handling</h3><div class="task-list">${ordered.length?ordered.slice(0,4).map(taskRow).join(''):'<p>Du har ingen åpne steg akkurat nå.</p>'}</div><h3>Hvor du er i reisen</h3><div class="process-flow">${processMarkup(idx)}</div>`;
+  $$('#participantDetail .task-row').forEach(b=>b.addEventListener('click',()=>openTask(b.dataset.taskId)));
+};
+
+const staffRenderForms=renderForms;
+renderForms=function(){
+  if(isStaff())return staffRenderForms();
+  const p=ownParticipant(),keys=participantFormKeys(p?.stage),participant=p?.id||'';
+  const defs=formDefs.filter(f=>(f.scope==='participant'||f.scope==='participant_staff')&&keys.has(f.key));
+  $('#formLibrary').innerHTML=defs.length?defs.map((f,i)=>`<a class="form-module" style="text-decoration:none;color:inherit" href="./form-runner.html?key=${encodeURIComponent(f.key)}${participant?'&participant='+encodeURIComponent(participant):''}"><span class="num">${String(i+1).padStart(2,'0')}</span><h3>${escapeHtml(f.title_no)}</h3><p>${escapeHtml(f.key==='info_before_via'?'Kort informasjon før du går videre.':f.key==='via_roadmap'?'Ditt veikart og neste avklaringer i VÍA.':f.key==='participant_agreement'?'Avtaler og kontaktvalg som gjelder reisen din.':f.key==='ser_daily'?'Din korte daglige SER-oppfølging.':'Din levende VIDA-plan og neste handling hjemme.')}</p><div class="meta"><span>${escapeHtml(stageLabel(p?.stage||'VIA'))}</span><span>Åpne →</span></div></a>`).join(''):'<p>Ingen skjemaer krever noe fra deg i denne fasen.</p>';
+};
+
+const staffRenderAnalysis=renderAnalysis;
+renderAnalysis=function(){
+  if(isStaff())return staffRenderAnalysis();
+  const avg=$('#showAverage');if(avg)avg.checked=false;
+  staffRenderAnalysis();
+  $('#analysisParticipants')?.classList.add('hidden');avg?.closest('label')?.classList.add('hidden');
+};
+
+function adaptParticipantChrome(){
+  if(isStaff())return;
+  const p=ownParticipant(),open=participantOpenTasks(p),overdue=t=>!!t.due_at&&new Date(t.due_at)<new Date(),important=open.filter(t=>severity(t)==='RED'||overdue(t)).length,clarify=open.filter(t=>severity(t)==='YELLOW'&&!overdue(t)).length,phase=stageLabel(p?.stage||'VIA');
+  const cards=$$('#view-overview .metric-grid .metric');
+  const setCard=(i,label,value,hint)=>{const c=cards[i];if(!c)return;c.querySelector('span').textContent=label;c.querySelector('strong').textContent=value;c.querySelector('small').textContent=hint};
+  setCard(0,'Mine åpne steg',open.length,'det du kan gjøre nå');setCard(1,'Viktig nå',important,'prioritert for deg');setCard(2,'Trenger avklaring',clarify,'kan vente på svar');setCard(3,'Min fase',phase,participantStageCopy(p?.stage));
+  const pulse=$('#groupPulse')?.closest('.panel-card');if(pulse){pulse.querySelector('.eyebrow').textContent='Din rytme';pulse.querySelector('h3').textContent='Siste status'}
+  const chart=$('#overviewChart')?.closest('.panel-card');if(chart){chart.querySelector('.eyebrow').textContent='Din utvikling';chart.querySelector('h3').textContent='Siste 30 dager';const b=chart.querySelector('[data-go="analysis"]');if(b)b.textContent='Se min utvikling'}
+  const analysis=$('#view-analysis .section-head');if(analysis){analysis.querySelector('.eyebrow').textContent='Dine målinger';analysis.querySelector('h2').textContent='Din utvikling over tid';analysis.querySelector('p').textContent='Se dine egne målinger som støtte for refleksjon og samtale. En skår er ikke en diagnose eller en automatisk beslutning.'}
+  $('#analysisParticipants')?.classList.add('hidden');$('#showAverage')?.closest('label')?.classList.add('hidden');
+  const formsHead=$('#view-forms .section-head');if(formsHead){formsHead.querySelector('.eyebrow').textContent='Din reise';formsHead.querySelector('h2').textContent='Dine steg og skjemaer';formsHead.querySelector('p').textContent='Bare det som er relevant i fasen din vises her.'}
+  $('#view-forms .reference-card')?.classList.add('hidden');
+  const checkStatus=$('#dayStatus')?.closest('label');checkStatus?.classList.add('hidden');
+  const documentsHead=$('#view-documents .section-head');if(documentsHead){documentsHead.querySelector('p').textContent='Dokumenter som gjelder reisen din samles her når de er klare.';documentsHead.querySelector('button')?.classList.add('hidden')}
+  const docNote=$('#view-documents .privacy-note');if(docNote)docNote.textContent='Du ser bare dokumenter kontoen din har tilgang til.';
+  const red=$('#mobileAttentionBar [data-attention="RED"]'),yellow=$('#mobileAttentionBar [data-attention="YELLOW"]');if(red)red.innerHTML=`<b>${important}</b> viktig/forfalt`;if(yellow)yellow.innerHTML=`<b>${clarify}</b> avklaringer`;
+}
+
+const participantOpenTask=openTask;
+openTask=function(id){
+  participantOpenTask(id);if(isStaff())return;const t=tasks.find(x=>x.id===id);if(!t)return;$('#taskDialogEyebrow').textContent=`${participantTaskTone(t)} · ${statusText(t.status)}`;
+};
+
+const participantRenderAll=renderAll;
+renderAll=function(){participantRenderAll();if(!isStaff())adaptParticipantChrome()};
+
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -9,6 +9,7 @@ const uxPath=path.join(dir,'app-ux.js');
 const onboardingPath=path.join(dir,'app-onboarding.js');
 const mobilePath=path.join(dir,'app-mobile.js');
 const contextPath=path.join(dir,'app-context.js');
+const participantPath=path.join(dir,'app-participant.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -16,6 +17,7 @@ const ux=fs.readFileSync(uxPath,'utf8');
 const onboarding=fs.readFileSync(onboardingPath,'utf8');
 const mobile=fs.readFileSync(mobilePath,'utf8');
 const context=fs.readFileSync(contextPath,'utf8');
+const participant=fs.readFileSync(participantPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -59,5 +61,6 @@ code += '\n\n/* UX/auth/mobile hardening is maintained separately and concatenat
 code += '\n\n/* Role onboarding navigation is maintained separately. */\n'+onboarding+'\n';
 code += '\n\n/* Mobile parity and navigation behavior are maintained separately. */\n'+mobile+'\n';
 code += '\n\n/* Role-aware context drill-down / action resolver is concatenated last so it wraps the final task dialog behavior. */\n'+context+'\n';
+code += '\n\n/* Participant-first presentation is concatenated last so it can soften staff language without weakening authorization. */\n'+participant+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/journey-role-smoke.mjs
+++ b/portal/journey-role-smoke.mjs
@@ -7,6 +7,7 @@ const journey=read('./USER_JOURNEY.md');
 const e2e=read('./END_TO_END_ROLE_JOURNEY.md');
 const intakeHtml=read('./intake.html');
 const intakeJs=read('./intake.js');
+const participantJs=read('./app-participant.js');
 const roleMatrix=read('./ROLE_SCOPE_QA_MATRIX.md');
 const qaHtml=read('./qa-role-pack.html');
 const qaJs=read('./qa-role-pack.js');
@@ -14,6 +15,7 @@ const formJs=read('./form-runner.js');
 const crmJs=read('./crm.js');
 const publicN1=read('../public-site/current/n1-ux.js');
 const qaFunction=read('../supabase/functions/qa-create-role-pack/index.ts');
+const intakeFunction=read('../supabase/functions/intake-command/index.ts');
 
 // Public N1: exactly three stages; safety is cross-cutting, not stage 4.
 assert(publicN1.includes("items[3].remove()"),'N1 must remove the fourth journey-ribbon item');
@@ -30,7 +32,17 @@ assert(intakeJs.includes("get('n2qa')==='1'"),'N2 must retain explicit synthetic
 assert(intakeHtml.includes('ingen data lagres'),'N2 must tell the tester that QA data is not persisted');
 assert(intakeJs.includes("client.functions.invoke('intake-command'"),'N2 must use the authorized intake command');
 assert(!intakeJs.includes("client.from('intakes')"),'N2 must not fall back to direct intake-table access');
-assert(e2e.includes('intake-command')&&e2e.includes('ikke funnet'),'Recoverability gap for intake-command must stay visible until closed');
+assert(intakeFunction.includes("action==='CONVERT_TO_VIA'")&&intakeFunction.includes('manage_intakes'),'Recovered intake-command source must remain version-controlled and authorization-aware');
+assert(e2e.includes('intake-command')&&e2e.includes('gjenopprettet'),'End-to-end journey must record the closed intake-command recovery item');
+
+// Participant-first N3: same secure portal, different mental model. Internal staff labels must not leak into the participant journey.
+assert(participantJs.includes('ownParticipant()'),'Participant layer must anchor to the authenticated participant journey');
+assert(participantJs.includes("return new Set(['info_before_via','via_roadmap','participant_agreement'])"),'VÍA participant must see only relevant participant-facing forms');
+assert(participantJs.includes("$('#dayStatus')?.closest('label')")&&participantJs.includes("classList.add('hidden')"),'Participant must not be asked to set internal RAG day status');
+assert(participantJs.includes("$('#showAverage')")&&participantJs.includes("analysisParticipants")&&participantJs.includes("classList.add('hidden')"),'Participant analysis must not expose staff/group comparison controls');
+for(const text of ['Mine åpne steg','Viktig nå','Min fase','Din neste handling','Dine steg og skjemaer'])assert(participantJs.includes(text),`Participant-first copy missing: ${text}`);
+assert(!participantJs.includes("'Kritisk'"),'Participant-first layer must not label own tasks with internal critical wording');
+assert(participantJs.includes("if(isStaff())return staffRenderParticipants()"),'Staff participant workspace must remain unchanged by participant-first layer');
 
 // Canonical forms must be represented in the portal and holistic journey.
 const formKeys=['info_before_via','interest_referral','via_roadmap','individual_go_no_go','participant_agreement','pilot_go','ser_daily','incident','vida_plan','pilot_evaluation'];


### PR DESCRIPTION
## Mål
Gjør første innloggede deltakeropplevelse til én personlig VÍA-reise, ikke et nedskalert medarbeiderdashboard.

## Hva endres
- nytt presentasjonslag `app-participant.js`, bygget sist i portalbundle
- deltakertekst bruker «mine steg», «viktig nå», «min fase» og «din neste handling»
- interne RAG-/kritisk-begreper skjules/oversettes i deltakerflaten
- gruppesammenligning og gruppesnitt skjules for deltaker
- deltakerens daglige innsjekk viser ikke staff-only dags-RAG
- skjemaoversikt filtreres etter deltakerens fase og participant/participant_staff scope
- staff/admin-rendering beholdes uendret og eksisterende RLS/rolleautorisasjon svekkes ikke
- ende-til-ende-dokumentasjon oppdateres for den nå lukkede `intake-command`-kildegjelden
- holistic journey smoke dekker participant-first invariantene

## Risiko og reversering
Kun frontend-/build-/QA-lag; ingen DDL, migrasjon eller ny datatilgang. Hele pakken kan reverseres via Git. Autorisasjon ligger fortsatt i eksisterende RLS/roller/serverkommandoer.