### PR TITLE
N3: turn account link into a concrete first VÍA action

### DIFF
--- a/portal/app-participant-next.js
+++ b/portal/app-participant-next.js
@@ -1,0 +1,45 @@
+(()=>{
+'use strict';
+
+function participantNextAction(participant,task){
+  if(!participant)return null;
+  const phase=stageLabel(participant.stage);
+  if(phase==='VÍA'||phase==='ny VÍA')return{
+    label:task?.workflow_key==='participant_via_start'?'Start mitt VÍA-veikart':'Åpne mitt VÍA-veikart',
+    href:`./form-runner.html?key=via_roadmap&participant=${encodeURIComponent(participant.id)}`,
+    hint:'Her avklarer du retning, ressurser og det som må være på plass før neste beslutning. Dette er ikke en GO/NO-GO-beslutning.'
+  };
+  if(phase==='SER')return{
+    label:'Åpne dagens SER-steg',
+    href:`./form-runner.html?key=ser_daily&participant=${encodeURIComponent(participant.id)}`,
+    hint:'Kort innsjekk og det som er relevant for dagen. Pause, tilpasning og transport er legitime tiltak.'
+  };
+  if(phase==='VIDA')return{
+    label:'Åpne min VIDA-plan',
+    href:`./form-runner.html?key=vida_plan&participant=${encodeURIComponent(participant.id)}`,
+    hint:'Én levende plan med neste konkrete handling og avtalt oppfølging hjemme.'
+  };
+  return null;
+}
+
+const participantJourneyOpenTask=openTask;
+openTask=function(id){
+  participantJourneyOpenTask(id);
+  if(isStaff())return;
+  const task=tasks.find(x=>x.id===id),participant=ownParticipant();
+  if(!task||!participant||task.participant_id!==participant.id)return;
+  const next=participantNextAction(participant,task);if(!next)return;
+  const body=document.querySelector('#taskDialogBody');if(!body)return;
+
+  // Internal staff gate hints may already have been rendered by the shared task-dialog layer.
+  // They remain useful for staff, but a participant must see their own lawful next action instead.
+  body.querySelectorAll('.gate-link,.gate-link-locked,.gate-hint').forEach(el=>el.classList.add('hidden'));
+  body.querySelector('[data-participant-next-action]')?.remove();
+  const box=document.createElement('div');
+  box.dataset.participantNextAction='1';
+  box.className='task-crosslinks participant-next-action';
+  box.innerHTML=`<p class="eyebrow">Din neste handling</p><p>${escapeHtml(next.hint)}</p><div class="crosslink-grid"><a class="gate-link" href="${next.href}">${escapeHtml(next.label)}</a></div>`;
+  body.appendChild(box);
+};
+
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -10,6 +10,7 @@ const onboardingPath=path.join(dir,'app-onboarding.js');
 const mobilePath=path.join(dir,'app-mobile.js');
 const contextPath=path.join(dir,'app-context.js');
 const participantPath=path.join(dir,'app-participant.js');
+const participantNextPath=path.join(dir,'app-participant-next.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -18,6 +19,7 @@ const onboarding=fs.readFileSync(onboardingPath,'utf8');
 const mobile=fs.readFileSync(mobilePath,'utf8');
 const context=fs.readFileSync(contextPath,'utf8');
 const participant=fs.readFileSync(participantPath,'utf8');
+const participantNext=fs.readFileSync(participantNextPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -61,6 +63,7 @@ code += '\n\n/* UX/auth/mobile hardening is maintained separately and concatenat
 code += '\n\n/* Role onboarding navigation is maintained separately. */\n'+onboarding+'\n';
 code += '\n\n/* Mobile parity and navigation behavior are maintained separately. */\n'+mobile+'\n';
 code += '\n\n/* Role-aware context drill-down / action resolver is concatenated last so it wraps the final task dialog behavior. */\n'+context+'\n';
-code += '\n\n/* Participant-first presentation is concatenated last so it can soften staff language without weakening authorization. */\n'+participant+'\n';
+code += '\n\n/* Participant-first presentation is concatenated after shared role-aware behavior. */\n'+participant+'\n';
+code += '\n\n/* Participant next-action routing is last so shared staff gates cannot leak into the participant task dialog. */\n'+participantNext+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/journey-role-smoke.mjs
+++ b/portal/journey-role-smoke.mjs
@@ -8,6 +8,7 @@ const e2e=read('./END_TO_END_ROLE_JOURNEY.md');
 const intakeHtml=read('./intake.html');
 const intakeJs=read('./intake.js');
 const participantJs=read('./app-participant.js');
+const participantNextJs=read('./app-participant-next.js');
 const roleMatrix=read('./ROLE_SCOPE_QA_MATRIX.md');
 const qaHtml=read('./qa-role-pack.html');
 const qaJs=read('./qa-role-pack.js');
@@ -17,6 +18,7 @@ const crmJs=read('./crm.js');
 const publicN1=read('../public-site/current/n1-ux.js');
 const qaFunction=read('../supabase/functions/qa-create-role-pack/index.ts');
 const intakeFunction=read('../supabase/functions/intake-command/index.ts');
+const adminCreateParticipant=read('../supabase/functions/admin-create-participant/index.ts');
 const formCommand=read('../supabase/functions/form-command/index.ts');
 
 // Public N1: exactly three stages; safety is cross-cutting, not stage 4.
@@ -45,6 +47,15 @@ assert(participantJs.includes("$('#showAverage')")&&participantJs.includes('anal
 for(const text of ['Mine åpne steg','Viktig nå','Min fase','Din neste handling','Dine steg og skjemaer'])assert(participantJs.includes(text),`Participant-first copy missing: ${text}`);
 assert(!participantJs.includes("'Kritisk'"),'Participant-first layer must not label own tasks with internal critical wording');
 assert(participantJs.includes("if(isStaff())return staffRenderParticipants()"),'Staff participant workspace must remain unchanged by participant-first layer');
+
+// N3 must end in one concrete VÍA participant action, not merely a linked account.
+assert(adminCreateParticipant.includes("workflow_key:'participant_via_start'"),'Account linking must create/reuse the participant VÍA start task');
+assert(adminCreateParticipant.includes("eq('workflow_key','participant_via_start')")&&adminCreateParticipant.includes("eq('assignee_user_id',targetUserId)"),'VÍA start task must be duplicate-guarded for the linked participant account');
+assert(adminCreateParticipant.includes("title:'Din VÍA er klar'"),'The linked participant must receive a safe notification for the first VÍA step');
+assert(participantNextJs.includes('participant_via_start')&&participantNextJs.includes('Start mitt VÍA-veikart'),'Participant task dialog must expose the VÍA roadmap as the first action');
+assert(participantNextJs.includes('key=via_roadmap'),'Participant VÍA action must route to the participant-facing roadmap, not staff GO/NO-GO');
+assert(participantNextJs.includes('Dette er ikke en GO/NO-GO-beslutning'),'Participant copy must separate VÍA clarification from the formal staff decision gate');
+assert(participantNextJs.includes("if(isStaff())return"),'Participant next-action layer must not alter staff task-gate behavior');
 
 // Canonical forms must be represented in the portal and holistic journey.
 const formKeys=['info_before_via','interest_referral','via_roadmap','individual_go_no_go','participant_agreement','pilot_go','ser_daily','incident','vida_plan','pilot_evaluation'];

--- a/supabase/FUNCTION_SOURCE_PARITY_2026-08-22.md
+++ b/supabase/FUNCTION_SOURCE_PARITY_2026-08-22.md
@@ -12,7 +12,7 @@ Denne kontrollen ble utført mot aktivt Supabase-prosjekt `ibloovohuhrceivrvhvn`
 | public-intake | 2 | false, custom fail-closed gates | `d49b6f8249aaa10d197648061b96463367eb0b7bf4f57dcbdab3a07544bb2c87` |
 | bootstrap-owner-once | 3 | false, permanently closed/410 | `75c9c1714d56ffe504db80858b477beabd718ba54d4d6b6b7f141707e5a6c37a` |
 | rls-preview-selftest | 2 | false, permanently closed/410 | `a68e2a49987a7cef8232f492bfbe5827e60c9218accd6501a4f2603783f2cc1f` |
-| admin-create-participant | 2 | true | `0d7822e47193cf68eb747a19f35be0c0758402edb9cb5f9a8198bebe59590250` |
+| admin-create-participant | 3 | true | `3a9afdec37b1dc0a7b0fe5e7ac696b1e49477ace68a0f5c7d4a77b4c5547a41d` |
 | admin-list-access | 1 | true | `9404da12a4425a83f3b614c9d774fdcb550b7221483d977f0241785708a3c4b0` |
 | task-command | 2 | true | `d20b9d7b883e10188162e19203b812e759033305317d61e0b82f2ed5cd5848a3` |
 | workflow-command | 2 | true | `b612c7ac15adaa19d309c43287634afd2c657121c2f1fdd64a72e9701a691ee4` |
@@ -30,7 +30,7 @@ Denne kontrollen ble utført mot aktivt Supabase-prosjekt `ibloovohuhrceivrvhvn`
 ## Viktige funn
 
 - `public-intake` i Git var eldre enn aktiv Supabase-kode og er korrigert til live-versjonen. Ingen backend-redeploy ble gjort i parity-arbeidet.
-- `intake-command` og `admin-create-participant` ble gjenopprettet tidligere i N2→N3-pakken.
+- `intake-command` og `admin-create-participant` ble gjenopprettet tidligere i N2→N3-pakken; `admin-create-participant` ble deretter oppgradert til v3 i N3 for å sikre at konto-link også gir deltakeren én konkret første VÍA-handling.
 - `form-command` ble opprettet kilde-før-deploy i P0 form-write-pakken.
 - `bootstrap-owner-once` og `rls-preview-selftest` er fortsatt deployet, men returnerer permanent `410` og er ikke operative bakdører.
 - CI forventer nå eksplisitt hele 20-funksjonssettet. Ny funksjon eller slettet kilde krever en bevisst parity-oppdatering.

--- a/supabase/functions/admin-create-participant/index.ts
+++ b/supabase/functions/admin-create-participant/index.ts
@@ -65,6 +65,21 @@ Deno.serve(async(req:Request)=>{
   }
 
   if(pilotId){const {data:existingPilotLink,error:pilotLookupError}=await admin.from('pilot_participants').select('pilot_id,participant_id').eq('pilot_id',pilotId).eq('participant_id',participant.id).maybeSingle();if(pilotLookupError)throw pilotLookupError;if(!existingPilotLink){const {error:linkError}=await admin.from('pilot_participants').insert({pilot_id:pilotId,participant_id:participant.id,status:'ACTIVE'});if(linkError)throw linkError}}
-  return new Response(JSON.stringify({ok:true,participant,linkedExisting}),{status:200,headers})
+
+  // N3 must end in a real participant action, not merely an account link. Reuse any open
+  // participant_via_start task so repeated admin operations cannot create duplicate starts.
+  let startTask:any=null
+  const {data:existingStart,error:startLookupError}=await admin.from('tasks').select('id,status,due_at').eq('participant_id',participant.id).eq('assignee_user_id',targetUserId).eq('workflow_key','participant_via_start').in('status',['OPEN','IN_PROGRESS','WAITING']).order('created_at',{ascending:false}).limit(1).maybeSingle()
+  if(startLookupError)throw startLookupError
+  if(existingStart)startTask=existingStart
+  else{
+   const {data:createdStart,error:startError}=await admin.from('tasks').insert({organization_id:org.id,participant_id:participant.id,title:'Min VÍA – start her',description:'Start med VÍA-veikartet: retning, ressurser og det som må avklares før neste beslutning.',status:'OPEN',assignee_user_id:targetUserId,due_at:new Date(Date.now()+3*86400000).toISOString(),priority:3,severity:'GREEN',task_type:'WORKFLOW',created_by:userData.user.id,audience:'PARTICIPANT',workflow_key:'participant_via_start',source_type:'participant_account',source_id:participant.id}).select('id,status,due_at').single()
+   if(startError)throw startError
+   startTask=createdStart
+   await admin.from('notifications').insert({user_id:targetUserId,task_id:createdStart.id,kind:'TASK',title:'Din VÍA er klar',safe_preview:'Du har et nytt steg i AidMe VIDA.'})
+   await admin.from('workflow_events').insert({organization_id:org.id,participant_id:participant.id,actor_user_id:userData.user.id,event_type:'PARTICIPANT_VIA_START_READY',from_stage:'VIA',to_stage:'VIA',source_type:'task',source_id:createdStart.id,metadata:{account_linked:true}})
+  }
+
+  return new Response(JSON.stringify({ok:true,participant,linkedExisting,startTask}),{status:200,headers})
  }catch(error){console.error(error);return new Response(JSON.stringify({error:'CREATE_PARTICIPANT_FAILED'}),{status:500,headers})}
 })


### PR DESCRIPTION
## Mål
N3 skal ikke ende med «konto opprettet». Den inviterte deltakeren skal møte én konkret, riktig VÍA-handling.

## Backend
- `admin-create-participant` oppretter eller gjenbruker én `participant_via_start`-oppgave for den koblede kontoen
- duplikatvern på deltaker + bruker + workflow key + åpen status
- trygg varsling: «Din VÍA er klar»
- workflow-event `PARTICIPANT_VIA_START_READY`
- ingen ny deltaker, ingen automatisk SER-/GO-beslutning

## Portal
- nytt siste participant-lag oversetter deltakerens task-dialog til riktig lovlig handling
- VÍA/ny VÍA → `via_roadmap`
- SER → `ser_daily`
- VIDA → `vida_plan`
- intern staff GO/NO-GO-gate skjules fra deltakerens task-dialog, men beholdes uendret for staff
- VÍA-teksten sier eksplisitt at veikartet ikke er en GO/NO-GO-beslutning

## Sikkerhet
Eksisterende rolle/RLS/gate-modell endres ikke. Backend-endringen er systemadmin/AAL2-gatet som før. Deltaker får kun egen oppgave og egne participant-facing skjemaer.