### PR TITLE
Pre-SER: align participant agreement with active template and review handoff

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -94,3 +94,5 @@ jobs:
         run: node portal/via-handoff-smoke.mjs
       - name: Verify GO decision and pre-SER journey invariants
         run: node portal/go-decision-journey-smoke.mjs
+      - name: Verify pre-SER participant agreement/readiness v2 invariants
+        run: node portal/pre-ser-agreement-smoke.mjs

--- a/portal/app-go-decision.js
+++ b/portal/app-go-decision.js
@@ -16,9 +16,9 @@ function staffDecisionTaskGate(task,participant){
     hint:'Samlet Pilot-GO er registrert. Åpne deltakeren og bruk «Kontroller og start SER»; serveren gjør siste gatekontroll.'
   };
   if(task.workflow_key==='via_agreement_review')return{
-    label:'Åpne samlet Pilot-GO',
-    href:`./form-runner.html?key=pilot_go${pilot?.id?'&pilot='+encodeURIComponent(pilot.id):'&participant='+encodeURIComponent(participant.id)}`,
-    hint:'Deltakeravtalen er levert. Lukk review og eventuelle vilkår før samlet Pilot-GO.'
+    label:'Se fullført avtale / beredskap',
+    href:`./form-runner.html?key=participant_agreement&participant=${encodeURIComponent(participant.id)}&latest=1`,
+    hint:'Les deltakerens faktiske avtale, kontakt-/delingsvalg og beredskapsbekreftelser før review lukkes. Deretter er samlet Pilot-GO neste formelle gate; avtalen er ikke i seg selv en SER-godkjenning.'
   };
   return{
     label:'Åpne avtale / beredskap',

--- a/portal/form-review.js
+++ b/portal/form-review.js
@@ -30,11 +30,17 @@ function ensureReviewPanel(){
   document.querySelector('#submissionList')?.closest('.panel-card')?.insertAdjacentElement('afterend',panel);
   return panel;
 }
+function agreementReviewNext(){
+  if(!isStaff()||currentDef?.key!=='participant_agreement')return'';
+  const pilot=selectedPilot();
+  const href=pilot?.id?`./form-runner.html?key=pilot_go&pilot=${encodeURIComponent(pilot.id)}`:'./#tasks';
+  return `<div class="preview-strip pre-ser-review-next"><strong>Neste formelle gate:</strong> Lukk avtale-review og eventuelle individuelle vilkår før samlet Pilot-GO. Deltakeravtalen er dokumentasjon og beredskap – ikke SER-start.<div class="form-actions"><a class="ghost" href="./#tasks">Til oppgaver</a><a class="primary" href="${href}">${pilot?.id?'Åpne samlet Pilot-GO':'Tilbake til oppgaver'}</a></div></div>`;
+}
 function renderSubmissionReview(row){
   const panel=ensureReviewPanel();if(!panel||!currentVersion)return;
   const sections=currentVersion.schema_json?.sections||[];
   const body=sections.map(sec=>`<section class="form-section review-section"><h3>${esc(sec.title||'Del')}</h3><div class="dynamic-grid">${(sec.fields||[]).map(field=>`<div class="field-wrap${['textarea','action','multi_select'].includes(field.type)?' full':''}"><label><span>${esc(field.label||field.key)}</span><div class="review-value">${esc(reviewValue(row.payload?.[field.key]))}</div></label></div>`).join('')}</div></section>`).join('');
-  panel.innerHTML=`<div class="card-head"><div><p class="eyebrow">Fullført · skrivebeskyttet</p><h2>${esc(currentDef?.title_no||'Skjema')}</h2><p>${reviewFormatDate(row.submitted_at||row.updated_at||row.created_at)} · v${currentVersion.version}</p></div><button id="closeSubmissionReview" class="ghost" type="button">Lukk visning</button></div><p class="privacy-note">Dette er den lagrede versjonen. Formell beslutning tas i riktig senere gate; et fullført skjema kan ikke redigeres her.</p>${body}`;
+  panel.innerHTML=`<div class="card-head"><div><p class="eyebrow">Fullført · skrivebeskyttet</p><h2>${esc(currentDef?.title_no||'Skjema')}</h2><p>${reviewFormatDate(row.submitted_at||row.updated_at||row.created_at)} · v${currentVersion.version}</p></div><button id="closeSubmissionReview" class="ghost" type="button">Lukk visning</button></div><p class="privacy-note">Dette er den lagrede versjonen. Formell beslutning tas i riktig senere gate; et fullført skjema kan ikke redigeres her.</p>${body}${agreementReviewNext()}`;
   panel.classList.remove('hidden');
   panel.querySelector('#closeSubmissionReview')?.addEventListener('click',()=>{panel.classList.add('hidden');panel.innerHTML='';});
   panel.scrollIntoView({behavior:'smooth',block:'start'});
@@ -78,6 +84,11 @@ save=async function(status){
     let box=document.querySelector('#participantFormHandoff');
     if(!box){box=document.createElement('div');box.id='participantFormHandoff';box.className='preview-strip';$('#dynamicForm')?.insertAdjacentElement('afterend',box)}
     box.innerHTML='<strong>Veikartet er sendt videre.</strong> VÍA-ansvarlig går nå gjennom retning, ressurser, beredskap og VIDA-broen sammen med deg før en eventuell formell GO/NO-GO. Du trenger ikke «godkjenne deg selv». <a href="./">Tilbake til min reise</a>';
+  }
+  if(!isStaff()&&own&&participant?.id===own.id&&key==='participant_agreement'){
+    let box=document.querySelector('#participantFormHandoff');
+    if(!box){box=document.createElement('div');box.id='participantFormHandoff';box.className='preview-strip';$('#dynamicForm')?.insertAdjacentElement('afterend',box)}
+    box.innerHTML='<strong>Avtalen og kontaktvalgene dine er bekreftet.</strong> Programansvarlig kontrollerer nå avtale, beredskap og eventuelle vilkår før samlet Pilot-GO. Du trenger ikke gjøre noe mer her nå, og dette betyr ikke at SER har startet. <a href="./">Tilbake til min reise</a>';
   }
 };
 

--- a/portal/pre-ser-agreement-smoke.mjs
+++ b/portal/pre-ser-agreement-smoke.mjs
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+
+function read(path){return fs.readFileSync(new URL(path,import.meta.url),'utf8')}
+function assert(ok,msg){if(!ok)throw new Error(msg)}
+
+const migration=read('../supabase/migrations/20260822032000_participant_agreement_readiness_v2.sql');
+const guard=read('./form-runner-guard.js');
+const review=read('./form-review.js');
+const decision=read('./app-go-decision.js');
+
+for(const key of [
+  'voluntary_participation','peer_privacy','leader_safety_authority',
+  'emergency_contact_ready','vida_owner_known','routine_sharing_boundary',
+  'yellow_sharing_boundary','red_emergency_understood','media_consent_separate'
+]) assert(migration.includes(`'${key}'`),`Agreement v2 missing active-template field: ${key}`);
+
+assert(migration.includes("version=2")&&migration.includes("'participant_program_agreement',2"),'Program agreement must be explicitly versioned to v2');
+assert(migration.includes("'pilot_evaluation_optional',1"),'Optional evaluation must have a separate consent purpose');
+assert(migration.includes("case when eval_choice then 'GRANTED' else 'DECLINED' end"),'Optional evaluation choice must be recorded independently');
+assert(migration.includes('Foto/media')||migration.includes('foto/media'),'Program agreement must keep media consent separate');
+assert(migration.includes('Dette er ikke en ny helse- eller risikokartlegging'),'Participant agreement must not become a second health journal');
+
+assert(guard.includes('Denne bekreftelsen er påkrevd.')&&guard.includes('validateGroups()'),'Required agreement confirmations must be blocked in the UI before submit');
+assert(decision.includes('Se fullført avtale / beredskap'),'Staff agreement-review task must open the submitted evidence before Pilot-GO');
+assert(decision.includes("key=participant_agreement")&&decision.includes('latest=1'),'Staff review must open the latest read-only agreement submission');
+assert(review.includes("key==='participant_agreement'"),'Participant submission must have an explicit agreement handoff');
+assert(review.includes('dette betyr ikke at SER har startet'),'Participant must be told agreement completion is not SER start');
+assert(review.includes('Neste formelle gate:')&&review.includes('samlet Pilot-GO'),'Staff read-only review must explain the next formal gate');
+
+console.log('Pre-SER agreement/readiness v2 invariants OK');

--- a/supabase/migrations/20260822032000_participant_agreement_readiness_v2.sql
+++ b/supabase/migrations/20260822032000_participant_agreement_readiness_v2.sql
@@ -1,0 +1,143 @@
+-- AidMe VIDA: participant agreement/readiness v2 aligned with active NO template package.
+-- Source: SharePoint active Operativ_malpakke_VIA_SER_VIDA_v0_3_A4.
+-- Principles: no new health journal; confirm rights, safety frame, contact/sharing choices,
+-- separate optional evaluation consent, and preserve explicit participant-owned acknowledgement.
+
+do $$
+declare
+  def_id uuid;
+  ts timestamptz := now();
+begin
+  select id into def_id from public.form_definitions where key='participant_agreement' limit 1;
+  if def_id is null then
+    raise exception 'PARTICIPANT_AGREEMENT_FORM_DEFINITION_REQUIRED';
+  end if;
+
+  if not exists (
+    select 1 from public.form_versions where form_definition_id=def_id and version=2
+  ) then
+    update public.form_versions
+      set retired_at=coalesce(retired_at,ts)
+      where form_definition_id=def_id and retired_at is null;
+
+    insert into public.form_versions(
+      id,form_definition_id,version,schema_json,published_at,retired_at,created_at
+    ) values (
+      gen_random_uuid(),def_id,2,
+      jsonb_build_object(
+        'phase','VIA_SER',
+        'audience','participant_staff',
+        'intro','Dette er ikke en ny helse- eller risikokartlegging. Bekreft rammene, valgfriheten og kontakt-/delingsvalgene som skal være tydelige før SER. Ikke skriv helsehistorie eller traumatiske detaljer her.',
+        'sections',jsonb_build_array(
+          jsonb_build_object(
+            'title','Frivillighet, verdighet og sikkerhetsramme',
+            'fields',jsonb_build_array(
+              jsonb_build_object('key','understands_info','type','checkbox','label','Jeg har fått informasjon i et språk og format jeg forstår','required',true),
+              jsonb_build_object('key','voluntary_participation','type','checkbox','label','Jeg vet at deltakelse er frivillig, og at jeg kan be om pause, tilpasning eller avbrudd','required',true),
+              jsonb_build_object('key','not_treatment','type','checkbox','label','Jeg vet at programmet ikke er behandling eller akuttjeneste med mindre dette er særskilt organisert','required',true),
+              jsonb_build_object('key','adaptation_right','type','checkbox','label','Jeg kan be om pause, transport, kortere etappe eller avbrudd uten at det regnes som nederlag','required',true),
+              jsonb_build_object('key','privacy_choice','type','checkbox','label','Jeg kan velge stillhet og hva jeg deler; det er ingen krav om personlig deling','required',true),
+              jsonb_build_object('key','route_contact','type','checkbox','label','Jeg sier fra dersom jeg forlater avtalt rute/møtepunkt eller får problemer som påvirker sikkerheten','required',true),
+              jsonb_build_object('key','peer_privacy','type','checkbox','label','Jeg respekterer andre deltakeres privatliv og har ikke sikkerhets- eller behandlingsansvar for dem','required',true),
+              jsonb_build_object('key','leader_safety_authority','type','checkbox','label','Jeg forstår at operativ leder kan endre rute, tempo, overnatting eller min deltakelse når sikkerheten krever det','required',true)
+            )
+          ),
+          jsonb_build_object(
+            'title','Kontakt, VIDA-bro og delingsvalg',
+            'fields',jsonb_build_array(
+              jsonb_build_object('key','emergency_contact_ready','type','checkbox','label','Nødkontakt og kontaktvei er avklart før SER','required',true,'help','Navn og private detaljer skal ikke dobbelføres her dersom de allerede er registrert i sikker kontekst.'),
+              jsonb_build_object('key','vida_owner_known','type','checkbox','label','Jeg vet hvem som er navngitt VIDA-eier / oppfølgingskontakt etter hjemkomst','required',true),
+              jsonb_build_object('key','routine_sharing_boundary','type','text','label','Hva kan rutinemessig deles med avtalt kontakt eller partner?','required',true,'help','Skriv kort, for eksempel «kun nødvendig drift», «avtalt kort status» eller «ingenting utover nødvendig drift». Ikke skriv helsehistorie.'),
+              jsonb_build_object('key','yellow_sharing_boundary','type','text','label','Ved gul status: hvem kan kontaktes og hva kan deles?','required',true,'help','Kort kontakt-/delingsregel. Ikke skriv medisinske eller traumatiske detaljer.'),
+              jsonb_build_object('key','red_emergency_understood','type','checkbox','label','Jeg forstår at nødvendige opplysninger kan deles for å beskytte liv og helse der regelverket tillater eller krever det','required',true)
+            )
+          ),
+          jsonb_build_object(
+            'title','Separate valg som ikke avgjør deltakelse',
+            'fields',jsonb_build_array(
+              jsonb_build_object('key','media_consent_separate','type','checkbox','label','Jeg forstår at samtykke til bilder eller historier er separat fra programdeltakelse','required',true),
+              jsonb_build_object('key','pilot_evaluation_opt_in','type','checkbox','label','Jeg ønsker å delta i frivillig pilotevaluering utover det som er nødvendig for drift','required',false,'help','Valgfritt. Nei påvirker ikke deltakelse eller oppfølging.')
+            )
+          )
+        )
+      ),
+      ts,null,ts
+    );
+  end if;
+
+  if not exists (select 1 from public.consent_versions where key='participant_program_agreement' and version=2) then
+    update public.consent_versions
+      set retired_at=coalesce(retired_at,ts)
+      where key='participant_program_agreement' and retired_at is null;
+    insert into public.consent_versions(
+      id,key,version,purpose,content_no,content_en,effective_from,retired_at
+    ) values (
+      gen_random_uuid(),'participant_program_agreement',2,
+      'Dokumentere deltakerens egen bekreftelse av programinformasjon, frivillighet, sikkerhetsramme og kontakt-/delingsvalg før SER',
+      'AidMe VIDA er et frivillig VÍA–SER–VIDA-program og skal ikke forstås som behandling, kur eller garanti. Deltakeren kan be om hjelp, pause, transport, tilpasning eller avbrudd, og det er ingen plikt til personlig deling. Deltakeren skal kjenne sikkerhetsrammen, kontaktveien, navngitt VIDA-eier og egne avtalte delingsvalg. Operativ leder kan tilpasse eller avbryte gjennomføring når sikkerheten krever det. Samtykke til foto/media og frivillig pilotevaluering er separate valg og er ikke en forutsetning for deltakelse.',
+      'AidMe VIDA is a voluntary VÍA–SER–VIDA programme and is not treatment, a cure or a guaranteed outcome. The participant may ask for help, rest, transport, adaptation or interruption, with no requirement for personal disclosure. The participant should know the safety frame, contact route, named VIDA owner and agreed information-sharing boundaries. The operational lead may adapt or stop participation when safety requires it. Photo/media consent and optional pilot evaluation are separate choices and are not conditions of participation.',
+      ts,null
+    );
+  end if;
+
+  if not exists (select 1 from public.consent_versions where key='pilot_evaluation_optional' and version=1) then
+    insert into public.consent_versions(
+      id,key,version,purpose,content_no,content_en,effective_from,retired_at
+    ) values (
+      gen_random_uuid(),'pilot_evaluation_optional',1,
+      'Frivillig pilotevaluering utover nødvendig drift og sikkerhets-/kvalitetsoppfølging',
+      'Dette valget gjelder frivillig bruk av deltakerens tilbakemeldinger i pilotevaluering utover det som er nødvendig for drift, sikkerhet og lovpålagt dokumentasjon. Valget er frivillig og påvirker ikke deltakelse eller oppfølging.',
+      'This choice covers optional use of the participant’s feedback in pilot evaluation beyond what is necessary for operations, safety and required documentation. The choice is voluntary and does not affect participation or follow-up.',
+      ts,null
+    );
+  end if;
+end
+$$;
+
+create or replace function aidme_private.participant_agreement_consent_workflow()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  form_key text;
+  p_user uuid;
+  consent_id uuid;
+  eval_consent_id uuid;
+  eval_choice boolean;
+  staff_owner uuid;
+begin
+  if new.status<>'SUBMITTED' or (tg_op='UPDATE' and old.status='SUBMITTED') then return new; end if;
+  select fd.key into form_key from public.form_versions fv join public.form_definitions fd on fd.id=fv.form_definition_id where fv.id=new.form_version_id;
+  if form_key<>'participant_agreement' or new.participant_id is null then return new; end if;
+  select p.user_id into p_user from public.participants p where p.id=new.participant_id;
+  select cv.id into consent_id from public.consent_versions cv where cv.key='participant_program_agreement' and cv.effective_from<=coalesce(new.submitted_at,now()) and (cv.retired_at is null or cv.retired_at>coalesce(new.submitted_at,now())) order by cv.version desc limit 1;
+  if consent_id is null then raise exception 'ACTIVE_PARTICIPANT_AGREEMENT_VERSION_REQUIRED'; end if;
+
+  if p_user is not null and new.submitted_by=p_user then
+    if not exists (select 1 from public.consent_events ce where ce.participant_id=new.participant_id and ce.consent_version_id=consent_id and ce.decision='GRANTED') then
+      insert into public.consent_events(organization_id,participant_id,consent_version_id,decision,actor_user_id,occurred_at,evidence)
+      values(new.organization_id,new.participant_id,consent_id,'GRANTED',p_user,coalesce(new.submitted_at,now()),jsonb_build_object('form_submission_id',new.id,'source','participant_agreement'));
+    end if;
+
+    select cv.id into eval_consent_id from public.consent_versions cv where cv.key='pilot_evaluation_optional' and cv.effective_from<=coalesce(new.submitted_at,now()) and (cv.retired_at is null or cv.retired_at>coalesce(new.submitted_at,now())) order by cv.version desc limit 1;
+    eval_choice:=coalesce((new.payload->>'pilot_evaluation_opt_in')::boolean,false);
+    if eval_consent_id is not null then
+      insert into public.consent_events(organization_id,participant_id,consent_version_id,decision,actor_user_id,occurred_at,evidence)
+      values(new.organization_id,new.participant_id,eval_consent_id,case when eval_choice then 'GRANTED' else 'DECLINED' end,p_user,coalesce(new.submitted_at,now()),jsonb_build_object('form_submission_id',new.id,'source','participant_agreement','optional',true));
+    end if;
+
+    update public.tasks set status='DONE',updated_at=now()
+      where participant_id=new.participant_id and workflow_key='participant_agreement_ack' and status in ('OPEN','IN_PROGRESS','WAITING');
+  else
+    if p_user is not null then
+      perform aidme_private.enqueue_workflow_task(new.organization_id,new.participant_id,new.pilot_id,'participant_agreement_ack','Min VÍA – bekreft deltakeravtalen','Les programinformasjonen og bekreft selv når du er klar. Foto/media og frivillig pilotevaluering håndteres som separate valg.',p_user,now()+interval '3 days',3,'GREEN','PARTICIPANT','form_submission',new.id::text);
+    else
+      staff_owner:=aidme_private.pick_role_user(new.organization_id,new.participant_id,new.pilot_id,array['via_owner','program_lead']);
+      perform aidme_private.enqueue_workflow_task(new.organization_id,new.participant_id,new.pilot_id,'participant_agreement_identity','VÍA – deltakerbekreftelse mangler','Deltakeravtalen er registrert av medarbeider. Dokumenter deltakerens egen bekreftelse i egnet sikker kanal før videre gate. Valg til frivillig pilotevaluering skal ikke antas på deltakerens vegne.',staff_owner,now()+interval '3 days',2,'YELLOW','STAFF','form_submission',new.id::text);
+    end if;
+  end if;
+  return new;
+end
+$$;


### PR DESCRIPTION
## Mål
Lukke neste ende-til-ende-gap etter individuell GO: deltakeravtale/beredskap skal samsvare med aktiv SharePoint-malpakke og være et faktisk, lesbart kontrollpunkt før Pilot-GO – uten å bli en ny helsejournal.

## Faglig kilde
Aktiv SharePoint-master `Operativ_malpakke_VIA_SER_VIDA_v0_3_A4`:
- frivillighet og verdighet
- pause/transport/tilpasning/avbrudd
- ingen krav om personlig deling
- privatliv mellom deltakere
- operativ leders sikkerhetsmyndighet
- nødkontakt, VIDA-eier og kontakt-/delingsvalg
- foto/media separat
- frivillig pilotevaluering separat

## Endringer
- ny versjonert `participant_agreement` v2; v1 beholdes historisk
- ingen ny helse-/risikokartlegging og ingen dobbelføring av navn der det allerede finnes i sikker kontekst
- programavtale versjoneres til v2
- frivillig pilotevaluering får eget samtykkeformål og registreres separat GRANTED/DECLINED bare når deltakeren selv sender skjemaet
- staff som registrerer på vegne av deltaker kan ikke anta frivillig evalueringssamtykke
- avtale-review-oppgaven åpner faktisk siste fullførte avtale før Pilot-GO
- deltaker får eksplisitt beskjed etter innsending: avtalen er bekreftet, men SER har ikke startet
- staff-review viser neste formelle gate som Pilot-GO
- ny CI-invariant for hele pre-SER-avtalebroen

## Sikkerhet
Eksisterende AAL2, form-command, RLS, payload-validering, consent events, Pilot-GO-gate og START_SER-gate beholdes. Ingen reelle deltakerdata brukes i QA.