### PR TITLE
SER/VIDA: day-zero rhythm and one living plan

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -96,3 +96,5 @@ jobs:
         run: node portal/go-decision-journey-smoke.mjs
       - name: Verify pre-SER participant agreement/readiness v2 invariants
         run: node portal/pre-ser-agreement-smoke.mjs
+      - name: Verify SER day-zero / normal-day and VIDA living-plan invariants
+        run: node portal/ser-vida-journey-smoke.mjs

--- a/portal/SER_VIDA_JOURNEY_NOTES_2026-08-22.md
+++ b/portal/SER_VIDA_JOURNEY_NOTES_2026-08-22.md
@@ -1,0 +1,20 @@
+# SER day-0 / normaldag → VIDA
+
+Denne pakken er en additiv presentasjons- og navigasjonsforbedring. Den endrer ikke RLS, roller, backend-gater eller realdata-policy.
+
+## SER
+
+- Første SER-dag behandles som en egen menneskelig oppstart: orientering, kontaktvei, gjennomførbar start og kort innsjekk.
+- Normaldag bruker samme `ser_daily` som kanonisk deltakerhandling; ingen parallell journal eller alternativ skjemaflyt opprettes.
+- Pause, kortere etappe, transport og annen tilpasning beskrives som legitime valg, ikke som nederlag eller automatisk avvik.
+- Eksisterende staff-/sikkerhetsgater og hendelsesflyt beholdes uendret.
+
+## VIDA
+
+- VIDA presenteres som én levende plan med neste konkrete handling, ansvar og tidspunkt for oppfølging.
+- Eksisterende `vida_plan` er kanonisk inngang. Pakken skal ikke opprette parallelle planer eller nye datalagre.
+- Rolle/scope og eksisterende kommandolag er fortsatt autoritet.
+
+## Release-regel
+
+Pakken kan merge/deploy når Portal smoke er grønn. Den er reversibel og introduserer ingen nye backend-writes. Public realdata-intake påvirkes ikke og forblir CLOSED.

--- a/portal/app-ser-vida.js
+++ b/portal/app-ser-vida.js
@@ -1,0 +1,76 @@
+(()=>{
+'use strict';
+
+function serVidaParticipant(){
+  return isStaff()?participantById(selectedParticipantId):ownParticipant();
+}
+function serVidaPhase(p){return p?stageLabel(p.stage):null}
+function serVidaOpenTasks(p){return (tasks||[]).filter(t=>t.participant_id===p?.id&&['OPEN','IN_PROGRESS','WAITING'].includes(t.status))}
+function serVidaTodayModel(p){
+  if(!p)return null;
+  const phase=serVidaPhase(p),pilot=participantPilot(p.id),route=pilot?routeToday(pilot.id):null,checkin=latestCheckin(p.id),open=serVidaOpenTasks(p);
+  if(phase==='SER'){
+    const dayZero=!checkin;
+    return{
+      phase,
+      kicker:dayZero?'SER · første dag':'SER · i dag',
+      title:dayZero?'Start rolig – få rammene på plass':'Dagens rytme',
+      body:dayZero
+        ?'Første SER-dag handler om orientering, kontaktvei og en gjennomførbar start. Pause, kortere etappe, transport eller annen tilpasning er legitime valg.'
+        :'Bruk den korte innsjekken til å fange det som faktisk betyr noe i dag. En gul eller rød status er et signal om støtte og tilpasning – ikke prestasjon.',
+      route,
+      checkin,
+      open,
+      primary:`./form-runner.html?key=ser_daily&participant=${encodeURIComponent(p.id)}`,
+      primaryLabel:dayZero?'Gjør første SER-innsjekk':'Åpne dagens innsjekk'
+    };
+  }
+  if(phase==='VIDA')return{
+    phase,
+    kicker:'VIDA · hjemme',
+    title:'Én levende plan – neste konkrete handling',
+    body:'VIDA-planen skal være stedet du og avtalt oppfølgingskontakt holder neste handling, ansvar og oppfølging levende. Ikke lag parallelle planer hvis den eksisterende kan oppdateres.',
+    route:null,checkin,open,
+    primary:`./form-runner.html?key=vida_plan&participant=${encodeURIComponent(p.id)}`,
+    primaryLabel:'Åpne min levende VIDA-plan'
+  };
+  return null;
+}
+function serVidaCardHtml(m){
+  const route=m.route?`<div class="detail-stat"><span>Dagens etappe</span><strong>${escapeHtml(`${m.route.from_place} → ${m.route.to_place}${m.route.distance_km?` · ${m.route.distance_km} km`:''}`)}</strong></div>`:'';
+  const last=m.checkin?.checkin_date?escapeHtml(m.checkin.checkin_date):'Ingen ennå';
+  return `<section class="panel-card ser-vida-today" data-ser-vida-phase="${m.phase}"><div class="card-head"><div><p class="eyebrow">${escapeHtml(m.kicker)}</p><h3>${escapeHtml(m.title)}</h3></div><span class="pill">${escapeHtml(m.phase)}</span></div><p>${escapeHtml(m.body)}</p><div class="detail-grid">${route}<div class="detail-stat"><span>Siste innsjekk</span><strong>${last}</strong></div><div class="detail-stat"><span>Åpne steg</span><strong>${m.open.length}</strong></div></div><div class="form-actions"><a class="primary" href="${m.primary}">${escapeHtml(m.primaryLabel)}</a></div></section>`;
+}
+function renderSerVidaToday(){
+  const p=serVidaParticipant(),m=serVidaTodayModel(p);
+  document.querySelectorAll('.ser-vida-today').forEach(el=>el.remove());
+  if(!m)return;
+  const target=isStaff()?document.querySelector('#participantDetail'):document.querySelector('#participantDetail');
+  if(!target)return;
+  target.insertAdjacentHTML('beforeend',serVidaCardHtml(m));
+}
+
+const serVidaParticipantNext=typeof participantNextAction==='function'?participantNextAction:null;
+if(serVidaParticipantNext){
+  participantNextAction=function(participant,task){
+    const base=serVidaParticipantNext(participant,task);if(!participant)return base;
+    const phase=serVidaPhase(participant);
+    if(phase==='SER')return{
+      label:'Åpne dagens SER-steg',
+      href:`./form-runner.html?key=ser_daily&participant=${encodeURIComponent(participant.id)}`,
+      hint:latestCheckin(participant.id)?'Kort innsjekk for dagens rytme, støtte og tilpasning.':'Første SER-dag: orienter deg, bekreft kontaktveien og gjør en kort innsjekk. Du kan be om pause, kortere etappe, transport eller annen tilpasning.'
+    };
+    if(phase==='VIDA')return{
+      label:'Åpne min levende VIDA-plan',
+      href:`./form-runner.html?key=vida_plan&participant=${encodeURIComponent(participant.id)}`,
+      hint:'Hold én plan levende: neste konkrete handling, hvem som følger opp og når dere ser på den igjen.'
+    };
+    return base;
+  };
+}
+
+const serVidaRenderAll=renderAll;
+renderAll=function(){serVidaRenderAll();renderSerVidaToday()};
+setTimeout(renderSerVidaToday,140);
+
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -13,6 +13,7 @@ const participantPath=path.join(dir,'app-participant.js');
 const participantNextPath=path.join(dir,'app-participant-next.js');
 const viaHandoffPath=path.join(dir,'app-via-handoff.js');
 const goDecisionPath=path.join(dir,'app-go-decision.js');
+const serVidaPath=path.join(dir,'app-ser-vida.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -24,6 +25,7 @@ const participant=fs.readFileSync(participantPath,'utf8');
 const participantNext=fs.readFileSync(participantNextPath,'utf8');
 const viaHandoff=fs.readFileSync(viaHandoffPath,'utf8');
 const goDecision=fs.readFileSync(goDecisionPath,'utf8');
+const serVida=fs.readFileSync(serVidaPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -71,5 +73,6 @@ code += '\n\n/* Participant-first presentation is concatenated after shared role
 code += '\n\n/* Participant next-action routing is last so shared staff gates cannot leak into the participant task dialog. */\n'+participantNext+'\n';
 code += '\n\n/* Staff VÍA review handoff is final for staff tasks and is a no-op for participants. */\n'+viaHandoff+'\n';
 code += '\n\n/* GO decision handoff is appended last so agreement, Pilot-GO and SER-start routing can refine shared task shortcuts. */\n'+goDecision+'\n';
+code += '\n\n/* SER day-zero / normal-day and VIDA living-plan guidance is appended last and remains presentation-only. */\n'+serVida+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/ser-vida-journey-smoke.mjs
+++ b/portal/ser-vida-journey-smoke.mjs
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+
+function read(path){return fs.readFileSync(new URL(path,import.meta.url),'utf8')}
+function assert(ok,msg){if(!ok)throw new Error(msg)}
+
+const layer=read('./app-ser-vida.js');
+const build=read('./build-app.mjs');
+const participant=read('./app-participant.js');
+const participantNext=read('./app-participant-next.js');
+
+assert(build.includes("app-ser-vida.js")&&build.includes("'+serVida+'"),'SER/VIDA layer must be included in deterministic portal build');
+assert(layer.includes("phase==='SER'")&&layer.includes("phase==='VIDA'"),'Layer must handle SER and VIDA explicitly');
+assert(layer.includes('Første SER-dag')||layer.includes('første dag'),'SER day-zero must be a first-class participant state');
+assert(layer.includes('Pause, kortere etappe, transport')||layer.includes('pause, kortere etappe, transport'),'SER must preserve legitimate adaptation language');
+assert(layer.includes('Én levende plan')&&layer.includes('parallelle planer'),'VIDA must be framed as one living plan, not duplicate plans');
+assert(layer.includes('ser_daily')&&layer.includes('vida_plan'),'Participant actions must route only to canonical SER/VIDA forms');
+assert(!layer.includes('client.from(')&&!layer.includes('functions.invoke('),'SER/VIDA presentation layer must not add backend writes or bypass commands');
+assert(participant.includes("new Set(['ser_daily'])"),'Participant SER form scope must remain limited to ser_daily');
+assert(participant.includes("new Set(['vida_plan'])"),'Participant VIDA form scope must remain limited to vida_plan');
+assert(participantNext.includes("key=ser_daily")&&participantNext.includes("key=vida_plan"),'Existing canonical phase routing must remain present');
+
+console.log('SER day-zero / normal-day and VIDA living-plan invariants OK');


### PR DESCRIPTION
Additive, reversible continuation of the canonical journey after pre-SER readiness.

- makes SER day-0 explicit before normal daily rhythm;
- keeps `ser_daily` as the only canonical participant daily action;
- reinforces pause/shorter stage/transport/adaptation as legitimate options;
- presents VIDA as one living plan through existing `vida_plan`, not parallel plans;
- adds no backend writes, roles, RLS, realdata gates or command bypasses;
- adds deterministic bundle inclusion and CI invariants.

Release rule: merge only when Portal smoke is green. Public realdata intake remains CLOSED.