### PR TITLE
SER→VIDA: explicit staff handoff through existing workflow command

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -98,3 +98,5 @@ jobs:
         run: node portal/pre-ser-agreement-smoke.mjs
       - name: Verify SER day-zero / normal-day and VIDA living-plan invariants
         run: node portal/ser-vida-journey-smoke.mjs
+      - name: Verify explicit SER to VIDA staff handoff invariants
+        run: node portal/ser-vida-handoff-smoke.mjs

--- a/portal/app-ser-vida-handoff.js
+++ b/portal/app-ser-vida-handoff.js
@@ -1,0 +1,50 @@
+(()=>{
+'use strict';
+
+const SER_VIDA_HANDOFF_ERRORS={
+  MFA_REQUIRED:'Bekreft Authenticator før du starter VIDA.',
+  FORBIDDEN:'Din rolle har ikke tilgang til å starte VIDA for denne deltakeren.',
+  VIDA_REQUIRES_SER:'Deltakeren er ikke lenger i SER. Last arbeidsflaten på nytt.',
+  NAMED_VIDA_OWNER_REQUIRED:'Navngitt VIDA-eier mangler. Avklar ansvar før VIDA starter.',
+  PARTICIPANT_NOT_FOUND:'Deltakeren er ikke tilgjengelig i denne konteksten.',
+  STALE_STAGE:'Fasen ble endret et annet sted. Last arbeidsflaten på nytt.'
+};
+function serVidaHandoffError(code){return SER_VIDA_HANDOFF_ERRORS[code]||'VIDA kunne ikke startes. Ingen alternativ direkte databasevei ble brukt.'}
+function serVidaHandoffParticipant(){return isStaff()?participantById(selectedParticipantId):null}
+function serVidaHandoffOpenSerTasks(p){return (tasks||[]).filter(t=>t.participant_id===p?.id&&['OPEN','IN_PROGRESS','WAITING'].includes(t.status)&&String(t.workflow_key||'').startsWith('ser_'))}
+
+async function startVidaHandoff(p,button,message){
+  if(!p||p.stage!=='SER'){message.textContent='Deltakeren er ikke lenger i SER. Last arbeidsflaten på nytt.';return}
+  const open=serVidaHandoffOpenSerTasks(p),pilot=participantPilot(p.id);
+  const detail=open.length?` Det finnes ${open.length} åpne SER-oppgave${open.length===1?'':'r'}; de blir ikke automatisk markert ferdige.`:'';
+  const accepted=window.confirm(`Start VIDA for ${p.code_name}? Dette er en eksplisitt faseovergang fra SER til VIDA.${detail}`);
+  if(!accepted)return;
+  button.disabled=true;message.textContent='Kontrollerer tilgang og starter VIDA sikkert…';
+  const {data,error}=await client.functions.invoke('workflow-command',{body:{action:'START_VIDA',participantId:p.id,pilotId:pilot?.id||null}});
+  const code=data?.error||(!data?.ok&&error?'WORKFLOW_COMMAND_FAILED':null);
+  if(error||code){message.textContent=serVidaHandoffError(code);button.disabled=false;return}
+  message.textContent='VIDA er startet. Oppdaterer deltaker, oppgaver og levende plan…';
+  await loadData();
+  renderAll();
+}
+
+function renderSerVidaHandoff(){
+  document.querySelectorAll('.ser-vida-handoff').forEach(el=>el.remove());
+  if(!isStaff())return;
+  const p=serVidaHandoffParticipant();
+  if(!p||p.stage!=='SER')return;
+  const card=document.querySelector('.ser-vida-today[data-ser-vida-phase="SER"]');
+  if(!card)return;
+  const open=serVidaHandoffOpenSerTasks(p);
+  const box=document.createElement('div');box.className='ser-vida-handoff';
+  box.innerHTML=`<div class="detail-stat"><span>Neste fase</span><strong>SER → VIDA</strong></div><p class="privacy-note">VIDA starter ved en eksplisitt staff-handoff – ikke automatisk etter en innsjekk eller siste etappe. Serveren kontrollerer rolle og fase før overgangen. Eksisterende VIDA-arbeidsflyt og den kanoniske <code>vida_plan</code> beholdes.</p>${open.length?`<p class="gate-hint">${open.length} åpne SER-oppgave${open.length===1?'':'r'} er synlige som kontekst. De lukkes ikke automatisk av faseovergangen.</p>`:''}<div class="form-actions"><button class="primary" type="button" data-start-vida>Avslutt SER og start VIDA</button></div><p class="message" data-ser-vida-handoff-message aria-live="polite"></p>`;
+  card.appendChild(box);
+  const button=box.querySelector('[data-start-vida]'),message=box.querySelector('[data-ser-vida-handoff-message]');
+  button?.addEventListener('click',()=>startVidaHandoff(p,button,message));
+}
+
+const serVidaHandoffRenderAll=renderAll;
+renderAll=function(){serVidaHandoffRenderAll();setTimeout(renderSerVidaHandoff,0)};
+setTimeout(renderSerVidaHandoff,180);
+
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -14,6 +14,7 @@ const participantNextPath=path.join(dir,'app-participant-next.js');
 const viaHandoffPath=path.join(dir,'app-via-handoff.js');
 const goDecisionPath=path.join(dir,'app-go-decision.js');
 const serVidaPath=path.join(dir,'app-ser-vida.js');
+const serVidaHandoffPath=path.join(dir,'app-ser-vida-handoff.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -26,6 +27,7 @@ const participantNext=fs.readFileSync(participantNextPath,'utf8');
 const viaHandoff=fs.readFileSync(viaHandoffPath,'utf8');
 const goDecision=fs.readFileSync(goDecisionPath,'utf8');
 const serVida=fs.readFileSync(serVidaPath,'utf8');
+const serVidaHandoff=fs.readFileSync(serVidaHandoffPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -74,5 +76,6 @@ code += '\n\n/* Participant next-action routing is last so shared staff gates ca
 code += '\n\n/* Staff VÍA review handoff is final for staff tasks and is a no-op for participants. */\n'+viaHandoff+'\n';
 code += '\n\n/* GO decision handoff is appended last so agreement, Pilot-GO and SER-start routing can refine shared task shortcuts. */\n'+goDecision+'\n';
 code += '\n\n/* SER day-zero / normal-day and VIDA living-plan guidance is appended last and remains presentation-only. */\n'+serVida+'\n';
+code += '\n\n/* Explicit staff SER→VIDA handoff uses the existing workflow command and preserves participant-only phase actions. */\n'+serVidaHandoff+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/ser-vida-handoff-smoke.mjs
+++ b/portal/ser-vida-handoff-smoke.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+
+function read(path){return fs.readFileSync(new URL(path,import.meta.url),'utf8')}
+function assert(ok,msg){if(!ok)throw new Error(msg)}
+
+const layer=read('./app-ser-vida-handoff.js');
+const build=read('./build-app.mjs');
+
+assert(build.includes("app-ser-vida-handoff.js")&&build.includes("'+serVidaHandoff+'"),'SER→VIDA handoff layer must be included in deterministic portal build');
+assert(layer.includes('if(!isStaff())return'),'Participant sessions must never receive the staff phase-transition control');
+assert(layer.includes("p.stage!=='SER'")||layer.includes("p.stage==='SER'"),'SER→VIDA action must be stage constrained');
+assert(layer.includes("client.functions.invoke('workflow-command'")&&layer.includes("action:'START_VIDA'"),'Transition must use the existing workflow command and START_VIDA action');
+assert(!layer.includes('client.from('),'Handoff layer must not add direct database writes');
+assert(layer.includes('NAMED_VIDA_OWNER_REQUIRED')&&layer.includes('MFA_REQUIRED')&&layer.includes('FORBIDDEN'),'Known server-side transition gates must be surfaced safely');
+assert(layer.includes('loadData()')&&layer.includes('renderAll()'),'Successful transition must reload participants/tasks before rendering');
+assert(layer.includes('ikke automatisk')&&layer.includes('åpne SER-oppgave'),'Handoff copy must make the human transition explicit and avoid silently closing SER work');
+assert(layer.includes('window.confirm'),'Stage transition must require an explicit staff confirmation click');
+
+console.log('SER→VIDA explicit staff handoff invariants OK');


### PR DESCRIPTION
Closes the next sequential journey gate after SER day-0/normal-day. Adds a staff-only, explicit SER→VIDA transition control that uses the existing `workflow-command` / `START_VIDA` path, preserves server-side role/MFA/stage checks, never performs direct database writes, reloads participant/task state after success, and keeps participant-only SER/VIDA actions unchanged. Open SER tasks are shown as context and are never silently completed. Includes deterministic build wiring and dedicated CI invariants.