### PR TITLE
VIDA: surface 72h/14d/30d/90d as one living-plan rhythm

### DIFF
--- a/portal/app-ser-vida.js
+++ b/portal/app-ser-vida.js
@@ -1,11 +1,18 @@
 (()=>{
 'use strict';
 
+const VIDA_MILESTONE_LABELS={vida_72h:'72 timer',participant_vida_72h:'72 timer',vida_14d:'14 dager',vida_30d:'30 dager',vida_90d:'90 dager'};
 function serVidaParticipant(){
   return isStaff()?participantById(selectedParticipantId):ownParticipant();
 }
 function serVidaPhase(p){return p?stageLabel(p.stage):null}
 function serVidaOpenTasks(p){return (tasks||[]).filter(t=>t.participant_id===p?.id&&['OPEN','IN_PROGRESS','WAITING'].includes(t.status))}
+function serVidaMilestones(p){
+  const rows=(tasks||[]).filter(t=>t.participant_id===p?.id&&VIDA_MILESTONE_LABELS[t.workflow_key]);
+  const byKey=new Map();
+  rows.sort((a,b)=>new Date(a.due_at||'2999')-new Date(b.due_at||'2999')).forEach(t=>{if(!byKey.has(t.workflow_key))byKey.set(t.workflow_key,t)});
+  return [...byKey.values()];
+}
 function serVidaTodayModel(p){
   if(!p)return null;
   const phase=serVidaPhase(p),pilot=participantPilot(p.id),route=pilot?routeToday(pilot.id):null,checkin=latestCheckin(p.id),open=serVidaOpenTasks(p);
@@ -21,6 +28,7 @@ function serVidaTodayModel(p){
       route,
       checkin,
       open,
+      milestones:[],
       primary:`./form-runner.html?key=ser_daily&participant=${encodeURIComponent(p.id)}`,
       primaryLabel:dayZero?'Gjør første SER-innsjekk':'Åpne dagens innsjekk'
     };
@@ -29,23 +37,28 @@ function serVidaTodayModel(p){
     phase,
     kicker:'VIDA · hjemme',
     title:'Én levende plan – neste konkrete handling',
-    body:'VIDA-planen skal være stedet du og avtalt oppfølgingskontakt holder neste handling, ansvar og oppfølging levende. Ikke lag parallelle planer hvis den eksisterende kan oppdateres.',
-    route:null,checkin,open,
+    body:'VIDA-planen skal være stedet du og avtalt oppfølgingskontakt holder neste handling, ansvar og oppfølging levende. 72 timer, 14, 30 og 90 dager er oppfølgingstidspunkter for den samme planen – ikke fire nye planer.',
+    route:null,checkin,open,milestones:serVidaMilestones(p),
     primary:`./form-runner.html?key=vida_plan&participant=${encodeURIComponent(p.id)}`,
     primaryLabel:'Åpne min levende VIDA-plan'
   };
   return null;
 }
+function serVidaMilestoneHtml(m){
+  if(m.phase!=='VIDA'||!m.milestones?.length)return'';
+  const rows=m.milestones.map(t=>`<div class="detail-stat"><span>${escapeHtml(VIDA_MILESTONE_LABELS[t.workflow_key]||'Oppfølging')}</span><strong>${escapeHtml(statusText(t.status))} · ${escapeHtml(formatDate(t.due_at))}</strong></div>`).join('');
+  return `<div class="detail-grid vida-followup-rhythm">${rows}</div><p class="privacy-note">Milepælene er påminnelser om å se på samme levende VIDA-plan igjen. Neste handling kan endres uten å opprette parallelle planer.</p>`;
+}
 function serVidaCardHtml(m){
   const route=m.route?`<div class="detail-stat"><span>Dagens etappe</span><strong>${escapeHtml(`${m.route.from_place} → ${m.route.to_place}${m.route.distance_km?` · ${m.route.distance_km} km`:''}`)}</strong></div>`:'';
   const last=m.checkin?.checkin_date?escapeHtml(m.checkin.checkin_date):'Ingen ennå';
-  return `<section class="panel-card ser-vida-today" data-ser-vida-phase="${m.phase}"><div class="card-head"><div><p class="eyebrow">${escapeHtml(m.kicker)}</p><h3>${escapeHtml(m.title)}</h3></div><span class="pill">${escapeHtml(m.phase)}</span></div><p>${escapeHtml(m.body)}</p><div class="detail-grid">${route}<div class="detail-stat"><span>Siste innsjekk</span><strong>${last}</strong></div><div class="detail-stat"><span>Åpne steg</span><strong>${m.open.length}</strong></div></div><div class="form-actions"><a class="primary" href="${m.primary}">${escapeHtml(m.primaryLabel)}</a></div></section>`;
+  return `<section class="panel-card ser-vida-today" data-ser-vida-phase="${m.phase}"><div class="card-head"><div><p class="eyebrow">${escapeHtml(m.kicker)}</p><h3>${escapeHtml(m.title)}</h3></div><span class="pill">${escapeHtml(m.phase)}</span></div><p>${escapeHtml(m.body)}</p><div class="detail-grid">${route}<div class="detail-stat"><span>Siste innsjekk</span><strong>${last}</strong></div><div class="detail-stat"><span>Åpne steg</span><strong>${m.open.length}</strong></div></div>${serVidaMilestoneHtml(m)}<div class="form-actions"><a class="primary" href="${m.primary}">${escapeHtml(m.primaryLabel)}</a></div></section>`;
 }
 function renderSerVidaToday(){
   const p=serVidaParticipant(),m=serVidaTodayModel(p);
   document.querySelectorAll('.ser-vida-today').forEach(el=>el.remove());
   if(!m)return;
-  const target=isStaff()?document.querySelector('#participantDetail'):document.querySelector('#participantDetail');
+  const target=document.querySelector('#participantDetail');
   if(!target)return;
   target.insertAdjacentHTML('beforeend',serVidaCardHtml(m));
 }
@@ -63,7 +76,7 @@ if(serVidaParticipantNext){
     if(phase==='VIDA')return{
       label:'Åpne min levende VIDA-plan',
       href:`./form-runner.html?key=vida_plan&participant=${encodeURIComponent(participant.id)}`,
-      hint:'Hold én plan levende: neste konkrete handling, hvem som følger opp og når dere ser på den igjen.'
+      hint:'Hold én plan levende. 72 timer, 14, 30 og 90 dager er oppfølging av samme neste handling, ansvar og avtalt kontakt – ikke nye parallelle planer.'
     };
     return base;
   };

--- a/portal/ser-vida-journey-smoke.mjs
+++ b/portal/ser-vida-journey-smoke.mjs
@@ -14,6 +14,8 @@ assert(layer.includes('Første SER-dag')||layer.includes('første dag'),'SER day
 assert(layer.includes('Pause, kortere etappe, transport')||layer.includes('pause, kortere etappe, transport'),'SER must preserve legitimate adaptation language');
 assert(layer.includes('Én levende plan')&&layer.includes('parallelle planer'),'VIDA must be framed as one living plan, not duplicate plans');
 assert(layer.includes('ser_daily')&&layer.includes('vida_plan'),'Participant actions must route only to canonical SER/VIDA forms');
+assert(layer.includes('vida_72h')&&layer.includes('vida_14d')&&layer.includes('vida_30d')&&layer.includes('vida_90d'),'VIDA must surface the canonical 72h/14d/30d/90d follow-up rhythm');
+assert(layer.includes('oppfølgingstidspunkter for den samme planen')&&layer.includes('ikke fire nye planer'),'VIDA milestones must be explicitly framed as follow-up of one plan');
 assert(!layer.includes('client.from(')&&!layer.includes('functions.invoke('),'SER/VIDA presentation layer must not add backend writes or bypass commands');
 assert(participant.includes("new Set(['ser_daily'])"),'Participant SER form scope must remain limited to ser_daily');
 assert(participant.includes("new Set(['vida_plan'])"),'Participant VIDA form scope must remain limited to vida_plan');


### PR DESCRIPTION
Closes the next post-SER usability gate without adding new writes or data models. The existing workflow-command already creates canonical VIDA follow-up tasks at 72h, 14d, 30d and 90d; this PR makes those milestones visible in the VIDA participant/staff card while explicitly framing them as reviews of the same `vida_plan`, not separate plans. Keeps participant phase actions on canonical `vida_plan`, adds no direct database writes, and strengthens CI invariants.