### PR TITLE
VIDA: optional new VÍA as explicit new start point

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -100,3 +100,5 @@ jobs:
         run: node portal/ser-vida-journey-smoke.mjs
       - name: Verify explicit SER to VIDA staff handoff invariants
         run: node portal/ser-vida-handoff-smoke.mjs
+      - name: Verify optional new VIA handoff invariants
+        run: node portal/vida-new-via-smoke.mjs

--- a/portal/app-vida-new-via.js
+++ b/portal/app-vida-new-via.js
@@ -1,0 +1,45 @@
+(()=>{
+'use strict';
+
+const NEW_VIA_ERRORS={
+  MFA_REQUIRED:'Bekreft Authenticator før du starter en ny VÍA.',
+  FORBIDDEN:'Din rolle har ikke tilgang til å starte ny VÍA for denne deltakeren.',
+  NEW_VIA_REQUIRES_VIDA:'Ny VÍA kan bare startes fra aktiv VIDA-fase.',
+  PARTICIPANT_NOT_FOUND:'Deltakeren er ikke tilgjengelig i denne konteksten.',
+  STALE_STAGE:'Fasen ble endret et annet sted. Last arbeidsflaten på nytt.'
+};
+function newViaError(code){return NEW_VIA_ERRORS[code]||'Ny VÍA kunne ikke startes. Ingen alternativ direkte databasevei ble brukt.'}
+
+async function startOptionalNewVia(p,button,message){
+  if(!p||p.stage!=='VIDA'){message.textContent='Deltakeren er ikke lenger i VIDA. Last arbeidsflaten på nytt.';return}
+  const accepted=window.confirm(`Starte ny VÍA for ${p.code_name}? Dette er et valgfritt nytt startpunkt når retningen må justeres – ikke et obligatorisk fjerde programsteg.`);
+  if(!accepted)return;
+  button.disabled=true;message.textContent='Kontrollerer tilgang og starter ny VÍA…';
+  const pilot=participantPilot(p.id);
+  const {data,error}=await client.functions.invoke('workflow-command',{body:{action:'START_NEW_VIA',participantId:p.id,pilotId:pilot?.id||null}});
+  const code=data?.error||(!data?.ok&&error?'WORKFLOW_COMMAND_FAILED':null);
+  if(error||code){message.textContent=newViaError(code);button.disabled=false;return}
+  message.textContent='Ny VÍA er startet som nytt veivalg. Oppdaterer arbeidsflaten…';
+  await loadData();
+  renderAll();
+}
+
+function renderOptionalNewVia(){
+  document.querySelectorAll('.vida-new-via').forEach(el=>el.remove());
+  if(!isStaff())return;
+  const p=participantById(selectedParticipantId);
+  if(!p||p.stage!=='VIDA')return;
+  const card=document.querySelector('.ser-vida-today[data-ser-vida-phase="VIDA"]');
+  if(!card)return;
+  const box=document.createElement('div');box.className='vida-new-via';
+  box.innerHTML=`<div class="detail-stat"><span>Ved behov</span><strong>Ny VÍA · nytt startpunkt</strong></div><p class="privacy-note">VIDA er siste steg i den ordinære trestegsreisen. Ny VÍA brukes bare når deltakeren og ansvarlig oppfølging trenger et nytt veivalg. Det skjer aldri automatisk ved 90 dager eller fordi en oppfølgingsoppgave er ferdig.</p><div class="form-actions"><button class="secondary" type="button" data-start-new-via>Start ny VÍA ved behov</button></div><p class="message" data-new-via-message aria-live="polite"></p>`;
+  card.appendChild(box);
+  const button=box.querySelector('[data-start-new-via]'),message=box.querySelector('[data-new-via-message]');
+  button?.addEventListener('click',()=>startOptionalNewVia(p,button,message));
+}
+
+const newViaRenderAll=renderAll;
+renderAll=function(){newViaRenderAll();setTimeout(renderOptionalNewVia,0)};
+setTimeout(renderOptionalNewVia,200);
+
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -15,6 +15,7 @@ const viaHandoffPath=path.join(dir,'app-via-handoff.js');
 const goDecisionPath=path.join(dir,'app-go-decision.js');
 const serVidaPath=path.join(dir,'app-ser-vida.js');
 const serVidaHandoffPath=path.join(dir,'app-ser-vida-handoff.js');
+const vidaNewViaPath=path.join(dir,'app-vida-new-via.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -28,6 +29,7 @@ const viaHandoff=fs.readFileSync(viaHandoffPath,'utf8');
 const goDecision=fs.readFileSync(goDecisionPath,'utf8');
 const serVida=fs.readFileSync(serVidaPath,'utf8');
 const serVidaHandoff=fs.readFileSync(serVidaHandoffPath,'utf8');
+const vidaNewVia=fs.readFileSync(vidaNewViaPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -77,5 +79,6 @@ code += '\n\n/* Staff VÍA review handoff is final for staff tasks and is a no-o
 code += '\n\n/* GO decision handoff is appended last so agreement, Pilot-GO and SER-start routing can refine shared task shortcuts. */\n'+goDecision+'\n';
 code += '\n\n/* SER day-zero / normal-day and VIDA living-plan guidance is appended last and remains presentation-only. */\n'+serVida+'\n';
 code += '\n\n/* Explicit staff SER→VIDA handoff uses the existing workflow command and preserves participant-only phase actions. */\n'+serVidaHandoff+'\n';
+code += '\n\n/* Optional new VÍA remains an explicit staff-triggered new start point after VIDA, never an automatic fourth step. */\n'+vidaNewVia+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/vida-new-via-smoke.mjs
+++ b/portal/vida-new-via-smoke.mjs
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+
+function read(path){return fs.readFileSync(new URL(path,import.meta.url),'utf8')}
+function assert(ok,msg){if(!ok)throw new Error(msg)}
+
+const layer=read('./app-vida-new-via.js');
+const build=read('./build-app.mjs');
+const journey=read('./USER_JOURNEY.md');
+
+assert(build.includes("app-vida-new-via.js")&&build.includes("'+vidaNewVia+'"),'Optional new VÍA layer must be included in deterministic portal build');
+assert(layer.includes('if(!isStaff())return'),'Participant sessions must never receive the staff stage-transition control');
+assert(layer.includes("p.stage!=='VIDA'")||layer.includes("p.stage==='VIDA'"),'New VÍA action must only be available from VIDA');
+assert(layer.includes("client.functions.invoke('workflow-command'")&&layer.includes("action:'START_NEW_VIA'"),'Transition must use existing workflow command START_NEW_VIA');
+assert(!layer.includes('client.from('),'Optional new VÍA layer must not add direct database writes');
+assert(layer.includes('ikke et obligatorisk fjerde programsteg')&&layer.includes('aldri automatisk'),'UI must preserve the three-step public journey and optional nature of new VÍA');
+assert(layer.includes('window.confirm'),'New VÍA stage transition must require an explicit staff confirmation');
+assert(layer.includes('loadData()')&&layer.includes('renderAll()'),'Successful transition must reload canonical portal state');
+assert(journey.includes('ny VÍA')&&journey.includes('ikke et obligatorisk fjerde steg'),'Implementation must remain aligned with the documented journey rule');
+
+console.log('Optional new VÍA handoff invariants OK');


### PR DESCRIPTION
Adds the final optional handoff after VIDA without turning the public three-step journey into an automatic loop. Staff can explicitly start `START_NEW_VIA` only while the participant is in VIDA, through the existing `workflow-command`, with server-side role/MFA/stage gates preserved. Participant sessions never receive this stage-transition control. The UI states that new VÍA is a new start point only when direction must be adjusted, never an obligatory fourth step or automatic 90-day action. Includes deterministic build wiring and CI invariants; no direct database writes or new backend model.