### PR TITLE
Evaluation: add project-level aggregated pilot entry

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -102,3 +102,5 @@ jobs:
         run: node portal/ser-vida-handoff-smoke.mjs
       - name: Verify optional new VIA handoff invariants
         run: node portal/vida-new-via-smoke.mjs
+      - name: Verify aggregated pilot evaluation entry invariants
+        run: node portal/pilot-evaluation-smoke.mjs

--- a/portal/app-pilot-evaluation.js
+++ b/portal/app-pilot-evaluation.js
@@ -1,0 +1,20 @@
+(()=>{
+'use strict';
+
+function renderPilotEvaluationEntry(){
+  document.querySelector('#pilotEvaluationEntry')?.remove();
+  if(!hasRole('project_owner'))return;
+  const target=document.querySelector('#view-overview');if(!target)return;
+  const visible=(pilots||[]).filter(p=>p?.id);
+  if(!visible.length)return;
+  const box=document.createElement('article');box.id='pilotEvaluationEntry';box.className='panel-card';box.style.marginTop='14px';
+  const links=visible.map(p=>`<a class="gate-link" href="./form-runner.html?key=pilot_evaluation&pilot=${encodeURIComponent(p.id)}"><strong>${escapeHtml(p.name||'Pilot')}</strong><small>${escapeHtml([p.route_name,p.status].filter(Boolean).join(' · '))}</small></a>`).join('');
+  box.innerHTML=`<div class="card-head"><div><p class="eyebrow">Aggregert læring</p><h3>Pilotevaluering</h3></div><span class="pill">Prosjektnivå</span></div><p>Samle sikkerhet/avvik, deltakererfaring, ressursbruk og metodelæring på pilotnivå. Dette er programforbedring – ikke en ny deltakerport, individuell vurdering eller forutsetning for ny VÍA.</p><div class="crosslink-grid">${links}</div><p class="privacy-note">Bruk aggregert språk. Observatør/evaluator har aggregert lesetilgang som standard; denne skriveinngangen følger dagens <code>manage_program</code>-gate.</p>`;
+  target.appendChild(box);
+}
+
+const pilotEvaluationRenderAll=renderAll;
+renderAll=function(){pilotEvaluationRenderAll();setTimeout(renderPilotEvaluationEntry,0)};
+setTimeout(renderPilotEvaluationEntry,220);
+
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -17,6 +17,7 @@ const goDecisionPath=path.join(dir,'app-go-decision.js');
 const serVidaPath=path.join(dir,'app-ser-vida.js');
 const serVidaHandoffPath=path.join(dir,'app-ser-vida-handoff.js');
 const vidaNewViaPath=path.join(dir,'app-vida-new-via.js');
+const pilotEvaluationPath=path.join(dir,'app-pilot-evaluation.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -32,6 +33,7 @@ const goDecision=fs.readFileSync(goDecisionPath,'utf8');
 const serVida=fs.readFileSync(serVidaPath,'utf8');
 const serVidaHandoff=fs.readFileSync(serVidaHandoffPath,'utf8');
 const vidaNewVia=fs.readFileSync(vidaNewViaPath,'utf8');
+const pilotEvaluation=fs.readFileSync(pilotEvaluationPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -83,5 +85,6 @@ code += '\n\n/* GO decision handoff is appended last so agreement, Pilot-GO and 
 code += '\n\n/* SER day-zero / normal-day and VIDA living-plan guidance is appended last and remains presentation-only. */\n'+serVida+'\n';
 code += '\n\n/* Explicit staff SER→VIDA handoff uses the existing workflow command and preserves participant-only phase actions. */\n'+serVidaHandoff+'\n';
 code += '\n\n/* Optional new VÍA remains an explicit staff-triggered new start point after VIDA, never an automatic fourth step. */\n'+vidaNewVia+'\n';
+code += '\n\n/* Project-level pilot evaluation is an aggregated learning entry, not a participant gate. */\n'+pilotEvaluation+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/pilot-evaluation-smoke.mjs
+++ b/portal/pilot-evaluation-smoke.mjs
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+
+function read(path){return fs.readFileSync(new URL(path,import.meta.url),'utf8')}
+function assert(ok,msg){if(!ok)throw new Error(msg)}
+
+const layer=read('./app-pilot-evaluation.js');
+const build=read('./build-app.mjs');
+const runner=read('./form-runner.js');
+const journey=read('./END_TO_END_ROLE_JOURNEY.md');
+
+assert(build.includes("app-pilot-evaluation.js")&&build.includes("'+pilotEvaluation+'"),'Pilot evaluation entry must be in the deterministic production bundle');
+assert(layer.includes("hasRole('project_owner')"),'Pilot evaluation write entry must stay on the current manage_program/project-owner UI path');
+assert(layer.includes('key=pilot_evaluation&pilot='),'Evaluation entry must carry explicit pilot context and no participant context');
+assert(layer.includes('Aggregert læring')&&layer.includes('ikke en ny deltakerport'),'Evaluation UX must be program learning, not a participant gate');
+assert(layer.includes('view_aggregated')&&layer.includes('manage_program'),'UI must explain the current read/write role boundary');
+assert(!layer.includes('client.from(')&&!layer.includes('functions.invoke('),'Evaluation entry layer must be presentation/navigation only');
+assert(runner.includes("project_owner:['info_before_via','interest_referral','via_roadmap','participant_agreement','pilot_go','pilot_evaluation']"),'Existing form runner must keep pilot_evaluation available to project owner');
+assert(!runner.includes("evaluator:['pilot_evaluation']")&&!runner.includes("observer:['pilot_evaluation']"),'Do not silently widen evaluator/observer write UI');
+assert(journey.includes('| 11. Evaluering |')&&journey.includes('Aggregert læring → forbedring'),'Implementation must align with the documented evaluation journey');
+assert(journey.includes('Observatør/evaluator har aggregert tilgang som standard'),'Evaluator/observer boundary must remain source-aligned');
+
+console.log('Aggregated pilot evaluation entry invariants OK');

--- a/portal/pilot-evaluation-smoke.mjs
+++ b/portal/pilot-evaluation-smoke.mjs
@@ -12,7 +12,7 @@ assert(build.includes("app-pilot-evaluation.js")&&build.includes("'+pilotEvaluat
 assert(layer.includes("hasRole('project_owner')"),'Pilot evaluation write entry must stay on the current manage_program/project-owner UI path');
 assert(layer.includes('key=pilot_evaluation&pilot='),'Evaluation entry must carry explicit pilot context and no participant context');
 assert(layer.includes('Aggregert læring')&&layer.includes('ikke en ny deltakerport'),'Evaluation UX must be program learning, not a participant gate');
-assert(layer.includes('view_aggregated')&&layer.includes('manage_program'),'UI must explain the current read/write role boundary');
+assert(layer.includes('aggregert lesetilgang')&&layer.includes('manage_program'),'UI must explain the current read/write role boundary in user-facing language');
 assert(!layer.includes('client.from(')&&!layer.includes('functions.invoke('),'Evaluation entry layer must be presentation/navigation only');
 assert(runner.includes("project_owner:['info_before_via','interest_referral','via_roadmap','participant_agreement','pilot_go','pilot_evaluation']"),'Existing form runner must keep pilot_evaluation available to project owner');
 assert(!runner.includes("evaluator:['pilot_evaluation']")&&!runner.includes("observer:['pilot_evaluation']"),'Do not silently widen evaluator/observer write UI');


### PR DESCRIPTION
Makes the existing `pilot_evaluation` form discoverable as a project/pilot-level learning action without turning evaluation into a participant gate. Only project owner receives the write/navigation entry, matching the current live `manage_program` RLS gate. Links carry explicit pilot context and no participant context. Copy reinforces aggregate-only learning and the existing observer/evaluator `view_aggregated` boundary. Presentation/navigation only; no RLS, role, schema or backend-write changes.