### PR TITLE
Public N1: complete remaining owner feedback deltas

### DIFF
--- a/.github/workflows/public-site-smoke.yml
+++ b/.github/workflows/public-site-smoke.yml
@@ -40,6 +40,7 @@ jobs:
           test -f "$ROOT/n1-ux.js"
           test -f "$ROOT/n1-ux.css"
           test -f "$ROOT/n1-intake-safe.js"
+          test -f "$ROOT/n1-feedback-completion.js"
           test -f "$ROOT/takk.html"
           test -f "$ROOT/SOURCE_PARITY_MANIFEST_2026-08-18.json"
           grep -q 'naturalContentHeight' "$ROOT/site.js"
@@ -50,14 +51,16 @@ jobs:
           grep -q 'has-card-link' "$ROOT/site.js"
           grep -q 'my.AidMe' "$ROOT/site.js"
           grep -q 'n1-ux.js' "$ROOT/site.js"
+          grep -q 'n1-feedback-completion.js' "$ROOT/site.js"
           grep -q 'grid-template-columns: 1fr' "$ROOT/mobile-ux.css"
           grep -q 'Gå videre til VIDA' "$ROOT/ser.html"
           grep -q 'Under lading' "$ROOT/via.html"
           grep -q 'n1-intake-safe.js' "$ROOT/kontakt.html"
 
-          # Preserve exact known bytes for the previously verified mobile layer,
-          # then pin the two intentional N1 bridge deltas independently.
-          test "$(git hash-object "$ROOT/site.js")" = '0d209b97c3baeed3f1539462592aa3aaf7414484'
+          # Preserve exact known bytes for the verified layered public source.
+          # site.js intentionally changed in the feedback-completion release to
+          # sequence the additive feedback layer after canonical n1-ux.js.
+          test "$(git hash-object "$ROOT/site.js")" = 'fc994876dc3d6e920884b3f2fee4e0244ebd84fc'
           test "$(git hash-object "$ROOT/mobile-ux.css")" = '9512227a22ba281f94644887c5e723bedb8b02dd'
           test "$(git hash-object "$ROOT/kontakt.html")" = '2f4664cc1a6aca8184c20960c90dafd452d1fecb'
 
@@ -75,7 +78,7 @@ jobs:
 
           for item in manifest.get('files', []):
               rel = item['path']
-              # N1 changes are additive/reversible and explicitly pinned above.
+              # Layered public UX changes are additive/reversible and explicitly pinned above.
               if rel in layered:
                   continue
               expected_size = int(item['size'])
@@ -98,7 +101,7 @@ jobs:
                   print(f' - {error}', file=sys.stderr)
               sys.exit(1)
 
-          print('Baseline manifest parity passed; intentional N1 deltas passed pinned Git-blob checks.')
+          print('Baseline manifest parity passed; intentional layered deltas passed pinned Git-blob checks.')
           PY
 
           echo 'Public layered UX candidate integrity checks passed.'

--- a/public-site/current/FEEDBACK_COMPLETION_2026-08-22.md
+++ b/public-site/current/FEEDBACK_COMPLETION_2026-08-22.md
@@ -1,0 +1,22 @@
+# Public N1 feedback completion — 2026-08-22
+
+Source basis:
+- SharePoint `AIDME_NO_N1_PUBLIC_REISE_WORKPACKAGE_2026-08-21.md` (B1–B9 / G1–G9 synthesis)
+- SharePoint `AIDME_NO_UX_CONTENT_PLAN_2026-08-17.md`
+- Existing production source pinned at `58fb1cbea45d47d64feb4430ea57e6a914182d62`
+
+Implemented reversible deltas not already covered by the production N1 layer:
+- Hero explains the before–during–after model and target audience more explicitly.
+- First-screen Camino clarification adds no requirement for personal disclosure.
+- Porto→Santiago route section is made more concrete with selected milestones Porto / Valença–Tui / Pontevedra / Santiago.
+- Santiago copy explicitly bridges into VIDA instead of ending the narrative at arrival, with 72h / 14d / 30d / 90d rhythm.
+- SER adds the approved `Det er lov å være sliten` / `Pause er også fremdrift` adaptation message.
+- Participant page surfaces the approved human-language translations of GO / conditional GO / wait / other path.
+- VIDA explicitly reinforces one living plan across 72h / 14d / 30d / 90d.
+- Mobile route density and image-caption readability receive a small additive refinement.
+
+Intentionally not changed:
+- Public real-data intake remains governed by existing hardened `public-intake`, Turnstile/rate/privacy gates.
+- The optional free-text relevance field from the early workpackage is not reintroduced; current safety layer deliberately removes it to avoid unnecessary sensitive/free-text collection at first contact.
+- No new treatment, recovery, employment-effect or clinical promise is introduced.
+- Existing mobile accordion and clickable phase-card behavior are retained because they are already implemented.

--- a/public-site/current/site.js
+++ b/public-site/current/site.js
@@ -222,5 +222,13 @@
   const script = document.createElement("script");
   script.src = "n1-ux.js?v=20260821a";
   script.dataset.aidmeN1 = "1";
+  script.async = false;
+  script.addEventListener("load", () => {
+    const delta = document.createElement("script");
+    delta.src = "n1-feedback-completion.js?v=20260822a";
+    delta.dataset.aidmeN1FeedbackCompletion = "1";
+    delta.async = false;
+    document.body.appendChild(delta);
+  }, { once: true });
   document.body.appendChild(script);
 })();


### PR DESCRIPTION
Completes the remaining reversible public-homepage deltas documented in the SharePoint 2026-08-17 UX/content plan and the 2026-08-21 B1–B9/G1–G9 N1 workpackage, without reopening real-data intake or changing roles/backend. Adds clearer before–during–after hero explanation, no-personal-disclosure threshold language, concrete Porto→Valença/Tui→Pontevedra→Santiago milestones, SER pause/adaptation module, stronger Santiago→VIDA bridge, participant-friendly decision language, explicit one-plan 72h/14d/30d/90d rhythm, and small mobile density/caption refinements. Existing mobile accordion and clickable phase cards are retained rather than duplicated. Optional free-text intake is intentionally not reintroduced because the hardened safety layer deliberately removes it.