### PR TITLE
Public N1: make no-pressure Camino framing explicit

### DIFF
--- a/public-site/current/n1-feedback-completion.js
+++ b/public-site/current/n1-feedback-completion.js
@@ -67,8 +67,8 @@
     const clarifier=document.querySelector('.camino-clarifier');
     if(clarifier){
       const spans=clarifier.querySelectorAll(':scope > span');
-      if(spans[0]) spans[0].textContent='En virkelig vandring – og en arena for veien videre. Ingen tro, religiøs praksis eller bestemt livssyn kreves, og du trenger ikke dele mer personlig enn du selv ønsker.';
-      if(spans[1]) spans[1].textContent='A real walk – and an arena for the way forward. No faith, religious practice or particular worldview is required, and you do not have to share more personally than you choose.';
+      if(spans[0]) spans[0].textContent='En virkelig vandring – og en arena for veien videre. Ingen tro, religiøs praksis eller bestemt livssyn kreves. Ingen forkynnelse eller press til religiøse eller personlige handlinger – og du trenger ikke dele mer personlig enn du selv ønsker.';
+      if(spans[1]) spans[1].textContent='A real walk – and an arena for the way forward. No faith, religious practice or particular worldview is required. There is no preaching or pressure toward religious or personal acts, and you do not have to share more personally than you choose.';
     }
     const rs=document.querySelector('.route-shell');
     if(rs){


### PR DESCRIPTION
Closes the remaining source-explicit inclusion detail from the 2026-08-17 public UX/content plan: the first-screen Camino clarification now says there is no preaching or pressure toward religious or personal actions, while preserving the existing no-faith-requirement and no-personal-disclosure language. Text-only, reversible public delta; no intake, backend, role, privacy or real-data changes.