### PR TITLE
QA: validate current public source as top-level preprod

### DIFF
--- a/.github/workflows/public-top-level-preprod-cdp-qa.yml
+++ b/.github/workflows/public-top-level-preprod-cdp-qa.yml
@@ -1,0 +1,131 @@
+name: Public top-level exact viewport QA
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/public-top-level-preprod-cdp-qa.yml'
+      - 'public-site/current/**'
+
+permissions:
+  contents: read
+
+jobs:
+  exact-viewports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build current source in dev mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd public-site/current
+          CONTEXT=deploy-preview URL='https://dev.aidme.no' node seo-build.mjs
+          grep -q 'X-Robots-Tag: noindex, nofollow' _site/_headers
+
+      - name: Render exact CSS viewports through Chrome DevTools Protocol
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHROME="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium || command -v chromium-browser)"
+          test -n "$CHROME"
+          python3 -m pip install --quiet websocket-client
+          OUT="$GITHUB_WORKSPACE/exact-viewport-qa"
+          SITE="$GITHUB_WORKSPACE/public-site/current/_site"
+          mkdir -p "$OUT/screens"
+
+          python3 -m http.server 8878 --directory "$SITE" >/tmp/aidme-exact-http.log 2>&1 &
+          HTTP_PID=$!
+          "$CHROME" --headless=new --no-sandbox --disable-dev-shm-usage \
+            --remote-debugging-port=9222 --remote-allow-origins='*' \
+            --user-data-dir=/tmp/aidme-cdp-profile about:blank >/tmp/aidme-chrome-cdp.log 2>&1 &
+          CHROME_PID=$!
+          trap 'kill $HTTP_PID $CHROME_PID 2>/dev/null || true' EXIT
+
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9222/json/version >/dev/null; then break; fi
+            sleep 1
+          done
+          curl -fsS http://127.0.0.1:9222/json/version >/dev/null
+
+          python3 - <<'PY'
+          import base64, json, time, urllib.request
+          from pathlib import Path
+          import websocket
+
+          out=Path('exact-viewport-qa')
+          pages=['index','via','ser','vida','deltakere','partnere','ruter','om','kontakt']
+          widths=[320,360,390,412,1440]
+
+          targets=json.load(urllib.request.urlopen('http://127.0.0.1:9222/json/list'))
+          target=next(t for t in targets if t.get('type')=='page')
+          ws=websocket.create_connection(target['webSocketDebuggerUrl'],timeout=30)
+          seq=0
+          def call(method,params=None):
+              global seq
+              seq+=1; ident=seq
+              ws.send(json.dumps({'id':ident,'method':method,'params':params or {}}))
+              while True:
+                  msg=json.loads(ws.recv())
+                  if msg.get('id')==ident:
+                      if 'error' in msg: raise RuntimeError(f'{method}: {msg["error"]}')
+                      return msg.get('result',{})
+
+          call('Page.enable'); call('Runtime.enable')
+          rows=[]
+          for page in pages:
+              for width in widths:
+                  mobile=width < 600
+                  call('Emulation.setDeviceMetricsOverride',{
+                      'width':width,'height':900,'deviceScaleFactor':1,'mobile':mobile,
+                      'screenWidth':width,'screenHeight':900
+                  })
+                  url=f'http://127.0.0.1:8878/{page}.html?qa=exact-{width}'
+                  call('Page.navigate',{'url':url})
+                  metrics=call('Runtime.evaluate',{
+                      'expression':'''(async()=>{await new Promise(r=>setTimeout(r,1400));await Promise.all([...document.images].map(i=>i.complete?Promise.resolve():new Promise(r=>{i.addEventListener('load',r,{once:true});i.addEventListener('error',r,{once:true});setTimeout(r,3000)})));const d=document.documentElement,f=document.querySelector('footer.site-footer');return {innerWidth:window.innerWidth,clientWidth:d.clientWidth,scrollWidth:d.scrollWidth,scrollHeight:d.scrollHeight,footerBottom:f?Math.ceil(f.getBoundingClientRect().bottom+window.scrollY):0,images:document.images.length,imageErrors:[...document.images].filter(i=>i.complete&&i.naturalWidth===0).length,h1:document.querySelectorAll('h1').length,footer:!!f};})()''',
+                      'awaitPromise':True,'returnByValue':True
+                  })['result']['value']
+                  inner=int(metrics['innerWidth']); client=int(metrics['clientWidth']); scroll=int(metrics['scrollWidth']); height=int(metrics['scrollHeight']); footer=int(metrics['footerBottom']); errors=int(metrics['imageErrors'])
+                  if abs(inner-width)>2 or abs(client-width)>2:
+                      raise SystemExit(f'viewport mismatch {page}@{width}: inner={inner} client={client}')
+                  if scroll>client+2:
+                      raise SystemExit(f'horizontal overflow {page}@{width}: scroll={scroll} client={client}')
+                  if not metrics['footer'] or footer<=0:
+                      raise SystemExit(f'missing footer {page}@{width}')
+                  if abs(height-footer)>160:
+                      raise SystemExit(f'blank tail/footer mismatch {page}@{width}: height={height} footer={footer}')
+                  if errors:
+                      raise SystemExit(f'broken images {page}@{width}: {errors}')
+                  if int(metrics['h1']) != 1:
+                      raise SystemExit(f'h1 count {page}@{width}: {metrics["h1"]}')
+                  rows.append((page,width,inner,client,scroll,height,footer,metrics['images'],errors))
+
+                  if width in (390,1440):
+                      layout=call('Page.getLayoutMetrics')
+                      size=layout['cssContentSize']
+                      shot=call('Page.captureScreenshot',{
+                          'format':'png','fromSurface':True,'captureBeyondViewport':True,
+                          'clip':{'x':0,'y':0,'width':size['width'],'height':size['height'],'scale':1}
+                      })
+                      label='mobile390' if width==390 else 'desktop1440'
+                      (out/'screens'/f'{page}-{label}.png').write_bytes(base64.b64decode(shot['data']))
+
+          ws.close()
+          with (out/'metrics.tsv').open('w',encoding='utf-8') as f:
+              f.write('page\trequestedWidth\tinnerWidth\tclientWidth\tscrollWidth\tscrollHeight\tfooterBottom\timages\timageErrors\n')
+              for row in rows: f.write('\t'.join(map(str,row))+'\n')
+          (out/'source-sha.txt').write_text('${{ github.sha }}\n',encoding='utf-8')
+          print((out/'metrics.tsv').read_text(encoding='utf-8'))
+          PY
+
+          test "$(find "$OUT/screens" -name '*.png' | wc -l | tr -d ' ')" = '18'
+          sha256sum "$OUT"/screens/*.png > "$OUT/SHA256SUMS.txt"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: aidme-public-exact-viewport-qa
+          path: exact-viewport-qa/
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/public-top-level-preprod-qa.yml
+++ b/.github/workflows/public-top-level-preprod-qa.yml
@@ -1,0 +1,163 @@
+name: Public top-level preprod QA
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/public-top-level-preprod-qa.yml'
+      - 'public-site/current/**'
+
+permissions:
+  contents: read
+
+jobs:
+  top-level-preprod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build exact current public source as dev preprod
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd public-site/current
+          CONTEXT=deploy-preview URL='https://dev.aidme.no' node seo-build.mjs | tee /tmp/public-build.log
+          grep -q 'noindex=true' /tmp/public-build.log
+          test -f _site/index.html
+          test -f _site/robots.txt
+          test -f _site/sitemap.xml
+          grep -q 'X-Robots-Tag: noindex, nofollow' _site/_headers
+          grep -qi '<meta name="robots" content="[^"]*noindex' _site/takk.html
+
+      - name: Validate routes, metadata and source integrity
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          from html.parser import HTMLParser
+          import re
+
+          root = Path('public-site/current/_site')
+          pages = ['index.html','via.html','ser.html','vida.html','deltakere.html','partnere.html','ruter.html','om.html','kontakt.html']
+
+          class Links(HTMLParser):
+              def __init__(self):
+                  super().__init__(); self.links=[]
+              def handle_starttag(self, tag, attrs):
+                  if tag != 'a': return
+                  href = dict(attrs).get('href')
+                  if href: self.links.append(href)
+
+          errors=[]
+          for page in pages:
+              path=root/page
+              if not path.is_file(): errors.append(f'MISSING {page}'); continue
+              text=path.read_text(encoding='utf-8')
+              if len(re.findall(r'<h1\b', text, flags=re.I)) != 1: errors.append(f'H1 {page}')
+              if '<footer class="site-footer"' not in text: errors.append(f'FOOTER {page}')
+              if 'rel="canonical"' not in text: errors.append(f'CANONICAL {page}')
+              if 'property="og:title"' not in text or 'property="og:url"' not in text: errors.append(f'OG {page}')
+              parser=Links(); parser.feed(text)
+              for href in parser.links:
+                  if href.startswith(('#','mailto:','tel:','http://','https://')): continue
+                  target=href.split('?',1)[0].split('#',1)[0] or page
+                  if target == '/': target='index.html'
+                  target=target.lstrip('/')
+                  if not (root/target).exists(): errors.append(f'BROKEN {page} -> {href}')
+          sitemap=(root/'sitemap.xml').read_text(encoding='utf-8')
+          if sitemap.count('<url>') != 9: errors.append('SITEMAP_COUNT')
+          contact=(root/'kontakt.html').read_text(encoding='utf-8')
+          if 'n1-intake-safe.js' not in contact: errors.append('CONTACT_FAILSAFE_SCRIPT')
+          if errors:
+              raise SystemExit('\n'.join(errors))
+          print('Static route/metadata/deep-link checks passed for all 9 indexable pages.')
+          PY
+          node --check public-site/current/site.js
+          node --check public-site/current/n1-ux.js
+          node --check public-site/current/n1-feedback-completion.js
+          node --check public-site/current/n1-intake-safe.js
+
+      - name: Render current-source mobile and desktop matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHROME="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium || command -v chromium-browser)"
+          test -n "$CHROME"
+          OUT="$GITHUB_WORKSPACE/top-level-qa"
+          SITE="$GITHUB_WORKSPACE/public-site/current/_site"
+          QA_SITE=/tmp/aidme-current-top-level
+          mkdir -p "$OUT/dom" "$OUT/screens" "$QA_SITE"
+          cp -a "$SITE"/. "$QA_SITE"/
+
+          # Add a hidden test-only marker to temporary copies so headless Chrome can
+          # expose computed overflow/footer metrics without changing repository source.
+          python3 - <<'PY'
+          from pathlib import Path
+          root=Path('/tmp/aidme-current-top-level')
+          pages=['index.html','via.html','ser.html','vida.html','deltakere.html','partnere.html','ruter.html','om.html','kontakt.html']
+          probe=r'''<script id="qa-probe">window.addEventListener('load',()=>setTimeout(()=>{const d=document.documentElement,b=document.body,f=document.querySelector('footer.site-footer');const m=document.createElement('div');m.id='qa-metrics';m.hidden=true;m.dataset.clientWidth=String(d.clientWidth);m.dataset.scrollWidth=String(d.scrollWidth);m.dataset.scrollHeight=String(d.scrollHeight);m.dataset.footerBottom=f?String(Math.ceil(f.getBoundingClientRect().bottom+window.scrollY)):'0';m.dataset.images=String([...document.images].filter(i=>i.complete&&i.naturalWidth>0).length);m.dataset.imageErrors=String([...document.images].filter(i=>i.complete&&i.naturalWidth===0).length);b.appendChild(m);},800));</script>'''
+          for page in pages:
+              p=root/page
+              text=p.read_text(encoding='utf-8')
+              if '</body>' not in text.lower(): raise SystemExit(f'no body close: {page}')
+              idx=text.lower().rfind('</body>')
+              p.write_text(text[:idx]+probe+text[idx:],encoding='utf-8')
+          PY
+
+          python3 -m http.server 8877 --directory "$QA_SITE" >/tmp/aidme-current-top-level.log 2>&1 &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+          sleep 1
+
+          pages=(index via ser vida deltakere partnere ruter om kontakt)
+          widths=(320 360 390 412 1440)
+          : > "$OUT/metrics.tsv"
+          printf 'page\twidth\tclientWidth\tscrollWidth\tscrollHeight\tfooterBottom\timages\timageErrors\n' >> "$OUT/metrics.tsv"
+
+          for page in "${pages[@]}"; do
+            for width in "${widths[@]}"; do
+              url="http://127.0.0.1:8877/${page}.html?qa=${GITHUB_SHA}"
+              dom="$OUT/dom/${page}-${width}.html"
+              timeout 45s "$CHROME" --headless=new --no-sandbox --disable-dev-shm-usage \
+                --hide-scrollbars --force-device-scale-factor=1 --window-size="${width},1000" \
+                --virtual-time-budget=12000 --dump-dom "$url" > "$dom" || test -s "$dom"
+              marker="$(grep -o '<div id="qa-metrics"[^>]*>' "$dom" | tail -1 || true)"
+              test -n "$marker"
+              python3 - "$page" "$width" "$marker" "$OUT/metrics.tsv" <<'PY'
+          import re,sys
+          page,width,marker,out=sys.argv[1:]
+          def n(key):
+              m=re.search(fr'data-{key}="([0-9]+)"',marker)
+              if not m: raise SystemExit(f'missing {key}: {page}@{width}')
+              return int(m.group(1))
+          client=n('client-width'); scroll=n('scroll-width'); height=n('scroll-height'); footer=n('footer-bottom'); images=n('images'); errors=n('image-errors')
+          if scroll > client + 2: raise SystemExit(f'horizontal overflow {page}@{width}: {scroll}>{client}')
+          if footer <= 0: raise SystemExit(f'missing footer metric {page}@{width}')
+          if height - footer > 160: raise SystemExit(f'blank tail {page}@{width}: {height-footer}px')
+          if errors: raise SystemExit(f'broken images {page}@{width}: {errors}')
+          with open(out,'a',encoding='utf-8') as f: f.write(f'{page}\t{width}\t{client}\t{scroll}\t{height}\t{footer}\t{images}\t{errors}\n')
+          PY
+            done
+
+            for spec in '390 3000 mobile' '1440 2400 desktop'; do
+              set -- $spec; width="$1"; height="$2"; label="$3"
+              timeout 45s "$CHROME" --headless=new --no-sandbox --disable-dev-shm-usage \
+                --hide-scrollbars --force-device-scale-factor=1 --window-size="${width},${height}" \
+                --virtual-time-budget=12000 --screenshot="$OUT/screens/${page}-${label}.png" \
+                "http://127.0.0.1:8877/${page}.html?qa=${GITHUB_SHA}"
+              test -s "$OUT/screens/${page}-${label}.png"
+            done
+          done
+
+          printf '%s\n' "$GITHUB_SHA" > "$OUT/source-sha.txt"
+          cp /tmp/public-build.log "$OUT/build.log"
+          sha256sum "$OUT"/screens/*.png > "$OUT/SHA256SUMS.txt"
+          cat "$OUT/metrics.tsv"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: aidme-public-current-top-level-qa
+          path: top-level-qa/
+          if-no-files-found: error
+          retention-days: 3


### PR DESCRIPTION
CAMINO PUBLIC SAFE HARBOR — A–E verification support.

Adds a QA-only workflow that builds the exact current `public-site/current` source in dev/preprod mode and validates it directly, rather than using the older hard-coded Netlify candidate.

Checks:
- all 9 indexable pages and internal deep links
- canonical/Open Graph/sitemap/robots output
- fail-closed contact + thank-you noindex invariants
- JavaScript syntax
- computed horizontal overflow + footer/blank-tail metrics at 320/360/390/412/1440 px
- broken images
- mobile and desktop screenshots for every public page

No public runtime, Wix, DNS, intake, or production code is changed by this PR.