### PR TITLE
Netlify: route main builds by site identity

### DIFF
--- a/.github/workflows/netlify-site-aware-router-qa.yml
+++ b/.github/workflows/netlify-site-aware-router-qa.yml
@@ -1,0 +1,79 @@
+name: Netlify site-aware router QA
+
+on:
+  pull_request:
+    paths:
+      - 'netlify.toml'
+      - 'netlify-build-router.mjs'
+      - '.github/workflows/netlify-site-aware-router-qa.yml'
+      - 'public-site/current/**'
+      - 'portal/**'
+      - 'vida/**'
+      - 'index.html'
+      - '_redirects'
+
+permissions:
+  contents: read
+
+jobs:
+  route-both-products:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate public dev route
+        shell: bash
+        env:
+          SITE_ID: 33549af8-6845-4c5b-b807-258ba5be1e99
+          SITE_NAME: dev-aidme-no
+          URL: https://dev.aidme.no
+          CONTEXT: production
+        run: |
+          set -euo pipefail
+          node netlify-build-router.mjs
+          test -f _netlify_publish/index.html
+          test -f _netlify_publish/via.html
+          test -f _netlify_publish/kontakt.html
+          test -f _netlify_publish/_headers
+          test -f _netlify_publish/robots.txt
+          grep -q 'X-Robots-Tag: noindex, nofollow' _netlify_publish/_headers
+          grep -q 'AidMe' _netlify_publish/index.html
+          if grep -q "location.replace('/portal/')" _netlify_publish/index.html; then
+            echo 'Public build accidentally contains portal root redirect' >&2
+            exit 1
+          fi
+          test ! -f _netlify_publish/_redirects
+
+      - name: Reset generated public output
+        shell: bash
+        run: rm -rf _netlify_publish public-site/current/_site
+
+      - name: Validate portal route parity
+        shell: bash
+        env:
+          SITE_ID: a90c686c-e9fc-4373-9956-629c9d31e622
+          SITE_NAME: mycamino
+          URL: https://my.aidme.no
+          CONTEXT: production
+        run: |
+          set -euo pipefail
+          node netlify-build-router.mjs
+          test -f _netlify_publish/index.html
+          test -f _netlify_publish/portal/index.html
+          test -f _netlify_publish/portal/app.js
+          test -f _netlify_publish/vida/forms.html
+          test -f _netlify_publish/vida/assets/AIDME_Logo-original-web.webp
+          test -f _netlify_publish/_redirects
+          grep -q "location.replace('/portal/')" _netlify_publish/index.html
+          grep -q '^/\* /index.html 200' _netlify_publish/_redirects
+          node --check _netlify_publish/portal/app.js
+
+      - name: Unknown target must fail closed
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf _netlify_publish
+          if SITE_ID=unknown SITE_NAME=unknown URL=https://unknown.example node netlify-build-router.mjs; then
+            echo 'Router should have refused unknown Netlify target' >&2
+            exit 1
+          fi

--- a/netlify-build-router.mjs
+++ b/netlify-build-router.mjs
@@ -1,0 +1,48 @@
+import { cp, mkdir, readdir, rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const root = process.cwd();
+const out = resolve(root, '_netlify_publish');
+const PUBLIC_SITE_ID = '33549af8-6845-4c5b-b807-258ba5be1e99';
+const PORTAL_SITE_ID = 'a90c686c-e9fc-4373-9956-629c9d31e622';
+
+const siteId = (process.env.SITE_ID || process.env.NETLIFY_SITE_ID || '').trim();
+const siteName = (process.env.SITE_NAME || '').trim().toLowerCase();
+let host = '';
+for (const key of ['URL', 'DEPLOY_PRIME_URL', 'DEPLOY_URL']) {
+  try {
+    const value = process.env[key];
+    if (value) { host = new URL(value).hostname.toLowerCase(); break; }
+  } catch {}
+}
+
+const isPublic = siteId === PUBLIC_SITE_ID || siteName === 'dev-aidme-no' || host === 'dev.aidme.no';
+const isPortal = siteId === PORTAL_SITE_ID || siteName === 'mycamino' || host === 'my.aidme.no' || host.endsWith('--mycamino.netlify.app') || host === 'mycamino.netlify.app';
+
+if (isPublic && isPortal) throw new Error(`Ambiguous Netlify target: siteId=${siteId} siteName=${siteName} host=${host}`);
+if (!isPublic && !isPortal) throw new Error(`Unknown Netlify target; refusing to publish the wrong product. siteId=${siteId || '(empty)'} siteName=${siteName || '(empty)'} host=${host || '(empty)'}`);
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: root, stdio: 'inherit', env: process.env });
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed with exit ${result.status}`);
+}
+
+await rm(out, { recursive: true, force: true });
+await mkdir(out, { recursive: true });
+
+if (isPublic) {
+  console.log(`Netlify build router: PUBLIC DEV (${siteId || siteName || host})`);
+  run(process.execPath, ['public-site/current/seo-build.mjs']);
+  await cp(resolve(root, 'public-site/current/_site'), out, { recursive: true });
+  console.log('Netlify build router: published public-site/current/_site -> _netlify_publish');
+} else {
+  console.log(`Netlify build router: PORTAL (${siteId || siteName || host})`);
+  run(process.execPath, ['portal/build-app.mjs']);
+  const excluded = new Set(['.git', '.netlify', 'node_modules', '_netlify_publish']);
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    if (excluded.has(entry.name)) continue;
+    await cp(resolve(root, entry.name), resolve(out, entry.name), { recursive: true });
+  }
+  console.log('Netlify build router: mirrored existing root publish output -> _netlify_publish');
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,3 @@
 [build]
-  publish = "."
-  command = "node portal/build-app.mjs"
-
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+  command = "node netlify-build-router.mjs"
+  publish = "_netlify_publish"


### PR DESCRIPTION
Permanent fix for the shared-repository Netlify conflict.

The root build now routes by Netlify site identity:
- `dev-aidme-no` (`33549af8-6845-4c5b-b807-258ba5be1e99`) builds `public-site/current` into a clean publish directory with dev noindex protection.
- `mycamino` (`a90c686c-e9fc-4373-9956-629c9d31e622`) runs the existing portal build and mirrors the prior root-publish behavior into the same clean publish directory.
- unknown targets fail closed rather than publishing the wrong product.

A dedicated QA workflow simulates both site IDs and verifies public routes/noindex, portal root/portal/vida assets, and fail-closed behavior.

This allows both Netlify projects to stay on `main`; no separate branch selection is required.