### PR TITLE
Netlify: add isolated public production target

### DIFF
--- a/.github/workflows/netlify-site-aware-router-qa.yml
+++ b/.github/workflows/netlify-site-aware-router-qa.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  route-both-products:
+  route-all-products:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,13 +38,45 @@ jobs:
           test -f _netlify_publish/robots.txt
           grep -q 'X-Robots-Tag: noindex, nofollow' _netlify_publish/_headers
           grep -q 'AidMe' _netlify_publish/index.html
+          grep -q 'rel="canonical" href="https://www.aidme.no/"' _netlify_publish/index.html
           if grep -q "location.replace('/portal/')" _netlify_publish/index.html; then
-            echo 'Public build accidentally contains portal root redirect' >&2
+            echo 'Public dev build accidentally contains portal root redirect' >&2
             exit 1
           fi
           test ! -f _netlify_publish/_redirects
 
-      - name: Reset generated public output
+      - name: Reset generated public dev output
+        shell: bash
+        run: rm -rf _netlify_publish public-site/current/_site
+
+      - name: Validate public production route
+        shell: bash
+        env:
+          SITE_ID: 1b763521-f8c0-462a-a0cc-915c1ae56d08
+          SITE_NAME: aidme-public-candidate-20260817
+          URL: https://aidme-public-candidate-20260817.netlify.app
+          CONTEXT: production
+        run: |
+          set -euo pipefail
+          node netlify-build-router.mjs
+          test -f _netlify_publish/index.html
+          test -f _netlify_publish/via.html
+          test -f _netlify_publish/kontakt.html
+          test -f _netlify_publish/robots.txt
+          test -f _netlify_publish/sitemap.xml
+          grep -q 'rel="canonical" href="https://www.aidme.no/"' _netlify_publish/index.html
+          grep -q 'https://www.aidme.no/sitemap.xml' _netlify_publish/robots.txt
+          if grep -Rqi 'X-Robots-Tag: noindex, nofollow' _netlify_publish/_headers 2>/dev/null; then
+            echo 'Public production build must not carry global noindex' >&2
+            exit 1
+          fi
+          if grep -q "location.replace('/portal/')" _netlify_publish/index.html; then
+            echo 'Public production build accidentally contains portal root redirect' >&2
+            exit 1
+          fi
+          test ! -f _netlify_publish/_redirects
+
+      - name: Reset generated public production output
         shell: bash
         run: rm -rf _netlify_publish public-site/current/_site
 

--- a/netlify-build-router.mjs
+++ b/netlify-build-router.mjs
@@ -4,7 +4,8 @@ import { resolve } from 'node:path';
 
 const root = process.cwd();
 const out = resolve(root, '_netlify_publish');
-const PUBLIC_SITE_ID = '33549af8-6845-4c5b-b807-258ba5be1e99';
+const PUBLIC_DEV_SITE_ID = '33549af8-6845-4c5b-b807-258ba5be1e99';
+const PUBLIC_PROD_SITE_ID = '1b763521-f8c0-462a-a0cc-915c1ae56d08';
 const PORTAL_SITE_ID = 'a90c686c-e9fc-4373-9956-629c9d31e622';
 
 const siteId = (process.env.SITE_ID || process.env.NETLIFY_SITE_ID || '').trim();
@@ -17,25 +18,31 @@ for (const key of ['URL', 'DEPLOY_PRIME_URL', 'DEPLOY_URL']) {
   } catch {}
 }
 
-const isPublic = siteId === PUBLIC_SITE_ID || siteName === 'dev-aidme-no' || host === 'dev.aidme.no';
+const isPublicDev = siteId === PUBLIC_DEV_SITE_ID || siteName === 'dev-aidme-no' || host === 'dev.aidme.no';
+const isPublicProd = siteId === PUBLIC_PROD_SITE_ID || siteName === 'aidme-public-candidate-20260817' || host === 'www.aidme.no' || host === 'aidme.no';
 const isPortal = siteId === PORTAL_SITE_ID || siteName === 'mycamino' || host === 'my.aidme.no' || host.endsWith('--mycamino.netlify.app') || host === 'mycamino.netlify.app';
+const matchCount = [isPublicDev, isPublicProd, isPortal].filter(Boolean).length;
 
-if (isPublic && isPortal) throw new Error(`Ambiguous Netlify target: siteId=${siteId} siteName=${siteName} host=${host}`);
-if (!isPublic && !isPortal) throw new Error(`Unknown Netlify target; refusing to publish the wrong product. siteId=${siteId || '(empty)'} siteName=${siteName || '(empty)'} host=${host || '(empty)'}`);
+if (matchCount > 1) throw new Error(`Ambiguous Netlify target: siteId=${siteId} siteName=${siteName} host=${host}`);
+if (matchCount === 0) throw new Error(`Unknown Netlify target; refusing to publish the wrong product. siteId=${siteId || '(empty)'} siteName=${siteName || '(empty)'} host=${host || '(empty)'}`);
 
-function run(command, args) {
-  const result = spawnSync(command, args, { cwd: root, stdio: 'inherit', env: process.env });
+function run(command, args, env = process.env) {
+  const result = spawnSync(command, args, { cwd: root, stdio: 'inherit', env });
   if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed with exit ${result.status}`);
 }
 
 await rm(out, { recursive: true, force: true });
 await mkdir(out, { recursive: true });
 
-if (isPublic) {
-  console.log(`Netlify build router: PUBLIC DEV (${siteId || siteName || host})`);
-  run(process.execPath, ['public-site/current/seo-build.mjs']);
+if (isPublicDev || isPublicProd) {
+  const mode = isPublicProd ? 'PUBLIC PROD' : 'PUBLIC DEV';
+  console.log(`Netlify build router: ${mode} (${siteId || siteName || host})`);
+  const buildEnv = isPublicProd
+    ? { ...process.env, URL: 'https://www.aidme.no', CONTEXT: 'production' }
+    : process.env;
+  run(process.execPath, ['public-site/current/seo-build.mjs'], buildEnv);
   await cp(resolve(root, 'public-site/current/_site'), out, { recursive: true });
-  console.log('Netlify build router: published public-site/current/_site -> _netlify_publish');
+  console.log(`Netlify build router: ${mode} published public-site/current/_site -> _netlify_publish`);
 } else {
   console.log(`Netlify build router: PORTAL (${siteId || siteName || host})`);
   run(process.execPath, ['portal/build-app.mjs']);


### PR DESCRIPTION
CAMINO PUBLIC SAFE HARBOR cutover preparation.

Extends the site-aware Netlify router to three isolated roles from the same GitHub `main` source:
- `dev-aidme-no` = public preprod, forced noindex
- `aidme-public-candidate-20260817` = public production, canonical/indexable as www.aidme.no
- `mycamino` = portal

Unknown or ambiguous site identity still fails closed.

QA now validates all three routes plus the existing fail-closed behavior. No DNS or custom-domain change is included in this PR.