### PR TITLE
SEO: align canonical with apex production domain

### DIFF
--- a/.github/workflows/ephemeral-visual-qa.yml
+++ b/.github/workflows/ephemeral-visual-qa.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate mobile-only fail-safe shell against immutable candidate and live Wix
+      - name: Validate rollback shell and direct Netlify production
         shell: bash
         run: |
           set -euo pipefail
@@ -26,7 +26,7 @@ jobs:
           mkdir -p visual-qa /tmp/aidme-shell-test /tmp/aidme-assets
 
           CANDIDATE='https://6a84e458653a15b76ca8f95e--aidme-public-candidate-20260817.netlify.app'
-          LIVE="https://www.aidme.no/?qa=${GITHUB_SHA}"
+          PROD='https://aidme-public-candidate-20260817.netlify.app'
           curl --fail --silent --show-error "${CANDIDATE}/site.js?qa=${GITHUB_SHA}" -o /tmp/candidate-site.js
           grep -q 'shellPresentation' /tmp/candidate-site.js
           grep -q 'aidme-shell' /tmp/candidate-site.js
@@ -43,6 +43,7 @@ jobs:
             file "/tmp/aidme-assets/${asset}" | grep -qi 'Web/P\|WebP'
           done
 
+          # Keep the old Wix wrapper fail-safe test as rollback coverage.
           cp ops/wix/aidme-public-shell.js /tmp/aidme-shell-test/shell.js
           {
             printf '%s\n' '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head><body style="margin:0"><div id="SITE_CONTAINER" style="height:420px;background:#ddd">LEGACY-FALLBACK</div><script>'
@@ -84,36 +85,23 @@ jobs:
           ! grep -q '<div id="aidme-public-git-shell"' visual-qa/desktop-dom.html
           grep -q 'LEGACY-FALLBACK' visual-qa/desktop-dom.html
 
-          # Live Wix may legitimately remain fail-safe in headless Chrome if the
-          # embedded Git page cannot be fully validated there. The invariant is
-          # therefore not "Git shell must always activate"; it is "never hide
-          # the Wix fallback unless a validated Git shell is active".
+          # Production is now top-level Netlify. It must render the public source
+          # directly and must not depend on the retired live Wix wrapper.
           timeout 45s "$CHROME" --headless=new --no-sandbox --disable-dev-shm-usage \
             --window-size=500,900 --virtual-time-budget=15000 --dump-dom \
-            "$LIVE" > visual-qa/live-mobile-dom.html || test -s visual-qa/live-mobile-dom.html
-          live_root=$(grep -o '<div id="aidme-public-git-shell"[^>]*>' visual-qa/live-mobile-dom.html | head -1 || true)
-          echo "LIVE_ROOT_TAG=$live_root"
-          test -n "$live_root"
-          if printf '%s' "$live_root" | grep -q 'data-state="active"'; then
-            grep -q 'data-aidme-legacy-hidden="1"' visual-qa/live-mobile-dom.html
-            live_host=$(printf '%s' "$live_root" | grep -o 'data-host-width="[0-9][0-9]*"' | head -1 | grep -o '[0-9][0-9]*' || true)
-            live_viewport=$(printf '%s' "$live_root" | grep -o 'data-viewport-width="[0-9][0-9]*"' | head -1 | grep -o '[0-9][0-9]*' || true)
-            test -n "$live_host"
-            test -n "$live_viewport"
-            live_delta=$(( live_host > live_viewport ? live_host - live_viewport : live_viewport - live_host ))
-            test "$live_delta" -le 2
-            printf 'live_outcome=validated-git-shell\n' >> visual-qa/result.txt
-          else
-            grep -q 'id="SITE_CONTAINER"' visual-qa/live-mobile-dom.html
-            ! grep -q 'data-aidme-legacy-hidden="1"' visual-qa/live-mobile-dom.html
-            printf '%s' "$live_root" | grep -Eq 'data-state="booting"|data-state="failed"'
-            printf 'live_outcome=visible-wix-fallback\n' >> visual-qa/result.txt
-          fi
+            "${PROD}/?qa=${GITHUB_SHA}" > visual-qa/prod-mobile-dom.html || test -s visual-qa/prod-mobile-dom.html
+          grep -q '<footer class="site-footer"' visual-qa/prod-mobile-dom.html
+          grep -q 'AidMe' visual-qa/prod-mobile-dom.html
+          ! grep -q '<div id="aidme-public-git-shell"' visual-qa/prod-mobile-dom.html
+          ! grep -q 'id="SITE_CONTAINER"' visual-qa/prod-mobile-dom.html
+          printf 'production_outcome=direct-netlify-public\n' >> visual-qa/result.txt
 
           timeout 45s "$CHROME" --headless=new --no-sandbox --disable-dev-shm-usage \
             --window-size=1440,900 --virtual-time-budget=12000 --dump-dom \
-            "$LIVE" > visual-qa/live-desktop-dom.html || test -s visual-qa/live-desktop-dom.html
-          ! grep -q '<div id="aidme-public-git-shell"' visual-qa/live-desktop-dom.html
+            "${PROD}/?qa=${GITHUB_SHA}" > visual-qa/prod-desktop-dom.html || test -s visual-qa/prod-desktop-dom.html
+          grep -q '<footer class="site-footer"' visual-qa/prod-desktop-dom.html
+          grep -q 'AidMe' visual-qa/prod-desktop-dom.html
+          ! grep -q '<div id="aidme-public-git-shell"' visual-qa/prod-desktop-dom.html
 
           capture() {
             local name="$1" width="$2" height="$3" url="$4"
@@ -126,8 +114,8 @@ jobs:
           capture shell-mobile 500 2200 'http://127.0.0.1:8765/'
           capture direct-mobile 500 2200 "${CANDIDATE}/?aidme-shell=1"
           capture direct-desktop 1440 1800 "${CANDIDATE}/?aidme-shell=1"
-          capture live-mobile 500 2200 "$LIVE"
-          capture live-desktop 1440 1800 "$LIVE"
+          capture production-mobile 500 2200 "${PROD}/?qa=${GITHUB_SHA}"
+          capture production-desktop 1440 1800 "${PROD}/?qa=${GITHUB_SHA}"
           sha256sum visual-qa/*.png > visual-qa/SHA256SUMS.txt
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/netlify-site-aware-router-qa.yml
+++ b/.github/workflows/netlify-site-aware-router-qa.yml
@@ -38,7 +38,7 @@ jobs:
           test -f _netlify_publish/robots.txt
           grep -q 'X-Robots-Tag: noindex, nofollow' _netlify_publish/_headers
           grep -q 'AidMe' _netlify_publish/index.html
-          grep -q 'rel="canonical" href="https://www.aidme.no/"' _netlify_publish/index.html
+          grep -q 'rel="canonical" href="https://aidme.no/"' _netlify_publish/index.html
           if grep -q "location.replace('/portal/')" _netlify_publish/index.html; then
             echo 'Public dev build accidentally contains portal root redirect' >&2
             exit 1
@@ -64,8 +64,8 @@ jobs:
           test -f _netlify_publish/kontakt.html
           test -f _netlify_publish/robots.txt
           test -f _netlify_publish/sitemap.xml
-          grep -q 'rel="canonical" href="https://www.aidme.no/"' _netlify_publish/index.html
-          grep -q 'https://www.aidme.no/sitemap.xml' _netlify_publish/robots.txt
+          grep -q 'rel="canonical" href="https://aidme.no/"' _netlify_publish/index.html
+          grep -q 'https://aidme.no/sitemap.xml' _netlify_publish/robots.txt
           if grep -Rqi 'X-Robots-Tag: noindex, nofollow' _netlify_publish/_headers 2>/dev/null; then
             echo 'Public production build must not carry global noindex' >&2
             exit 1

--- a/netlify-build-router.mjs
+++ b/netlify-build-router.mjs
@@ -38,7 +38,7 @@ if (isPublicDev || isPublicProd) {
   const mode = isPublicProd ? 'PUBLIC PROD' : 'PUBLIC DEV';
   console.log(`Netlify build router: ${mode} (${siteId || siteName || host})`);
   const buildEnv = isPublicProd
-    ? { ...process.env, URL: 'https://www.aidme.no', CONTEXT: 'production' }
+    ? { ...process.env, URL: 'https://aidme.no', CONTEXT: 'production' }
     : process.env;
   run(process.execPath, ['public-site/current/seo-build.mjs'], buildEnv);
   await cp(resolve(root, 'public-site/current/_site'), out, { recursive: true });

--- a/public-site/current/SOURCE_PARITY_MANIFEST_2026-08-18.json
+++ b/public-site/current/SOURCE_PARITY_MANIFEST_2026-08-18.json
@@ -26,7 +26,7 @@
     {"path":"prototype_manifest.json","size":747,"sha256":"9d831e9daea3b23983a84954cc52097075f9ecb7b763c919b5a3ba791efe362d"},
     {"path":"refine.css","size":13340,"sha256":"c70ac7eb37e7bee954125e199b85a65681dd142ca6951aea52efd5168855195a"},
     {"path":"ruter.html","size":18675,"sha256":"c7cc55af50f7b1f256fc628019357e22564e382de4580e33b3e44208d113ea1b"},
-    {"path":"seo-build.mjs","size":4064,"sha256":"184e856a28a2a87ca21a5bee9539e3ddfe41d20b727801d35cd241b146a26b4c"},
+    {"path":"seo-build.mjs","size":4060,"sha256":"d4a85af15976cbea301ad12a066b15e7e3c508dccf0defa604d01d0124e73fdb"},
     {"path":"ser.html","size":10827,"sha256":"9297d4d08ba1d1599e2c4f20faad39ed58209bb0b3d0fe5837b8e8d42e808b2a"},
     {"path":"site.css","size":11294,"sha256":"53f2739715e111fabd15a2941e8280be2552341a5b6519cf8775af192314b076"},
     {"path":"site.js","size":6382,"sha256":"212af44933bda211c1c88e3e4930815fec3a17187111d4bc4eb552688c820b7a"},

--- a/public-site/current/seo-build.mjs
+++ b/public-site/current/seo-build.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const out = join(here, '_site');
-const canonicalOrigin = 'https://www.aidme.no';
+const canonicalOrigin = 'https://aidme.no';
 const indexablePages = [
   'index.html',
   'via.html',


### PR DESCRIPTION
Post-cutover cleanup. Netlify has `aidme.no` as the primary production domain and redirects `www.aidme.no` to it. Align public canonical/OG/sitemap and production build environment to `https://aidme.no` so redirects and canonical agree. QA expectations updated accordingly. No DNS, portal, dev noindex, or intake changes.