### PR TITLE
Portal: remove email PII from N2→N3 handoff URL

### DIFF
--- a/portal/intake-n2-smoke.mjs
+++ b/portal/intake-n2-smoke.mjs
@@ -23,11 +23,15 @@ requireText('convert command',js,"cmd('CONVERT_TO_VIA'");
 requireText('terminal confirmation',js,'window.confirm');
 requireText('no-write qa copy',js,'Ingen data ble lagret');
 requireText('fail closed backend copy',js,'Ingen direkte databasevei brukes som reserve');
+requireText('N2 to N3 handoff keeps participant context',js,"participantId:String(participant?.id||'')");
 requireText('mobile target',css,'min-height:48px');
 requireText('reduced motion',css,'prefers-reduced-motion');
 
 for(const forbidden of ["client.from('intakes')",'client.from("intakes")',"client.from('participants')",'client.from("participants")']){
   if(js.includes(forbidden))throw new Error(`Direct DB write/read path forbidden in N2 intake UX: ${forbidden}`);
 }
+for(const forbidden of ["email:String(intake?.contact_email",'email:String(intake?.contact_email',"email:String(intake?.contact_email||'')"]){
+  if(js.includes(forbidden))throw new Error('N2→N3 handoff must not put contact email in URL/query parameters.');
+}
 if(!js.includes("if(QA_MODE)"))throw new Error('N2 QA mode must be explicit and opt-in');
-console.log('N2 intake triage invariants OK');
+console.log('N2 intake triage invariants OK, including PII-safe N2→N3 handoff URL.');

--- a/portal/intake.js
+++ b/portal/intake.js
@@ -5,7 +5,7 @@ const $=s=>document.querySelector(s);
 const QA_MODE=new URLSearchParams(location.search).get('n2qa')==='1';
 let session=null,rows=[],selectedId=null,qaRows=[];
 
-function esc(v=''){return String(v??'').replace(/[&<>'\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','\"':'&quot;'}[c]))}
+function esc(v=''){return String(v??'').replace(/[&<>'"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c]))}
 function statusLabel(status){return({NEW:'Ny',TRIAGE:'Trenger avklaring',REFERRED:'Anbefalt annen vei',CLOSED:'Avsluttet',CONVERTED:'VÍA opprettet'})[status]||status||'Ukjent'}
 function sourceLabel(source){return({PUBLIC_WEB:'aidme.no',WEB:'aidme.no',PARTNER:'Partner',NAV:'NAV / offentlig partner',SELF:'Egen interesse',STAFF:'Registrert av medarbeider'})[String(source||'').toUpperCase()]||source||'Ikke angitt'}
 function statusTone(status){return status==='NEW'?'YELLOW':status==='TRIAGE'?'GREEN':'neutral'}

--- a/portal/intake.js
+++ b/portal/intake.js
@@ -5,7 +5,7 @@ const $=s=>document.querySelector(s);
 const QA_MODE=new URLSearchParams(location.search).get('n2qa')==='1';
 let session=null,rows=[],selectedId=null,qaRows=[];
 
-function esc(v=''){return String(v??'').replace(/[&<>'"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c]))}
+function esc(v=''){return String(v??'').replace(/[&<>'\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','\"':'&quot;'}[c]))}
 function statusLabel(status){return({NEW:'Ny',TRIAGE:'Trenger avklaring',REFERRED:'Anbefalt annen vei',CLOSED:'Avsluttet',CONVERTED:'VÍA opprettet'})[status]||status||'Ukjent'}
 function sourceLabel(source){return({PUBLIC_WEB:'aidme.no',WEB:'aidme.no',PARTNER:'Partner',NAV:'NAV / offentlig partner',SELF:'Egen interesse',STAFF:'Registrert av medarbeider'})[String(source||'').toUpperCase()]||source||'Ikke angitt'}
 function statusTone(status){return status==='NEW'?'YELLOW':status==='TRIAGE'?'GREEN':'neutral'}
@@ -22,7 +22,7 @@ function setWorkspaceMessage(text,type='info'){
   const el=$('#workspaceMessage');if(!el)return;el.textContent=text||'';el.className=`message ${type==='success'?'auth-success':type==='error'?'auth-error':'auth-info'}`;
 }
 function hideHandoff(){const el=$('#n3Handoff');if(!el)return;el.classList.add('hidden');el.innerHTML=''}
-function adminHandoffUrl(participant,intake,codeName){const q=new URLSearchParams({from:'n2',participantId:String(participant?.id||''),codeName:String(participant?.code_name||codeName||''),email:String(intake?.contact_email||'')});return `./admin.html?${q.toString()}`}
+function adminHandoffUrl(participant,intake,codeName){const q=new URLSearchParams({from:'n2',participantId:String(participant?.id||''),codeName:String(participant?.code_name||codeName||'')});return `./admin.html?${q.toString()}`}
 function showHandoff(participant,intake,codeName,{qa=false}={}){
   const el=$('#n3Handoff');if(!el)return;const label=participant?.code_name||codeName||'VÍA-reisen';
   if(qa){el.innerHTML=`<div><p class="eyebrow">N3 · Konto og første VÍA-opplevelse</p><h2>Neste steg er tydelig</h2><p>Syretesten viser at <strong>${esc(label)}</strong> går videre til sikker kontoinvitasjon som et eget steg. Ingen konto, e-post eller backenddata opprettes i QA-modus.</p><div class="n3-meta">VÍA er opprettet før konto – SER er fortsatt ikke godkjent.</div></div><div class="n3-actions"><button class="ghost" type="button" id="dismissHandoff">Lukk syretest</button></div>`}


### PR DESCRIPTION
P1 privacy hardening in the existing N2→N3 workflow. Removes contact email from the admin handoff query string while retaining participant/workflow context. Adds a regression assertion to the N2 smoke test. No backend, RLS, role, real-data intake, or schema changes.