### PR TITLE
Security: fail closed stale N2→N3 participant linkage

### DIFF
--- a/portal/invite-stress-smoke.mjs
+++ b/portal/invite-stress-smoke.mjs
@@ -30,6 +30,8 @@ must(admin.includes("$('#inviteEmail').value=''"),'admin does not explicitly cle
 must(admin.includes("participantId,codeName,pilotId"),'admin invite does not pass existing participant id to server');
 must(admin.includes('ingen ny deltaker ble opprettet'),'admin confirmation does not preserve single-journey invariant');
 must(participant.includes("participantId=body?.participantId"),'server cannot receive existing participant id');
+must(participant.includes("PARTICIPANT_NOT_INVITABLE_FROM_N2")&&participant.includes("String(existingParticipant.stage).toUpperCase()!=='VIA'"),'server must fail closed if an N2 participant id no longer points to an active VIA journey');
+must(participant.includes("!existingParticipant.active"),'server must reject inactive participant linkage even if the client handoff is stale');
 must(participant.includes(".update({user_id:targetUserId,active:true,updated_at:now})"),'server does not link invited account to existing participant');
 must(participant.includes("PARTICIPANT_ALREADY_LINKED")&&participant.includes("USER_ALREADY_PARTICIPANT"),'duplicate/cross-link guards missing');
 must(participant.includes("PARTICIPANT_ACCOUNT_LINKED"),'account linkage is not audited/workflow logged');

--- a/supabase/functions/admin-create-participant/index.ts
+++ b/supabase/functions/admin-create-participant/index.ts
@@ -38,6 +38,7 @@ Deno.serve(async(req:Request)=>{
    const {data:existingParticipant,error:participantError}=await admin.from('participants').select('id,organization_id,user_id,code_name,stage,active').eq('id',participantId).eq('organization_id',org.id).maybeSingle()
    if(participantError)throw participantError
    if(!existingParticipant)return new Response(JSON.stringify({error:'PARTICIPANT_NOT_FOUND'}),{status:404,headers})
+   if(!existingParticipant.active||String(existingParticipant.stage).toUpperCase()!=='VIA')return new Response(JSON.stringify({error:'PARTICIPANT_NOT_INVITABLE_FROM_N2'}),{status:409,headers})
    if(existingForUser&&existingForUser.id!==participantId)return new Response(JSON.stringify({error:'USER_ALREADY_PARTICIPANT',participant:existingForUser}),{status:409,headers})
    if(existingParticipant.user_id&&existingParticipant.user_id!==targetUserId)return new Response(JSON.stringify({error:'PARTICIPANT_ALREADY_LINKED'}),{status:409,headers})
    if(existingParticipant.user_id===targetUserId){participant=existingParticipant;linkedExisting=true}


### PR DESCRIPTION
Hardens the existing N2 → N3 secure account-link flow without opening any data/scope gate.

- Server-side `admin-create-participant` now requires an existing handoff participant to be active and still in `VIA` before account linkage.
- Returns `PARTICIPANT_NOT_INVITABLE_FROM_N2` fail-closed instead of trusting the browser-only phase check.
- Extends invite/onboarding smoke to prevent regression.
- No schema, RLS, role, consent, or real-data changes.