### PR TITLE
Public QA: stabilize promoted feedback layer

### DIFF
--- a/.github/workflows/public-n1-feedback-completion.yml
+++ b/.github/workflows/public-n1-feedback-completion.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'public-site/current/n1-feedback-completion.js'
+      - 'public-site/current/post-cutover-live.js'
       - 'public-site/current/site.js'
       - 'ops/wix/aidme-public-n1-desktop-bridge.js'
       - 'ops/wix/aidme-public-n1-mobile-shell.js'
@@ -23,8 +24,13 @@ jobs:
         run: |
           set -euo pipefail
           node --check public-site/current/n1-feedback-completion.js
+          node --check public-site/current/post-cutover-live.js
           node --check public-site/current/site.js
           grep -q 'n1-feedback-completion.js' public-site/current/site.js
+          grep -q 'post-cutover-live.js' public-site/current/site.js
+          grep -q 'Camino Portugués' public-site/current/post-cutover-live.js
+          grep -q 'Oppfølging hjemme' public-site/current/post-cutover-live.js
+          grep -q 'DEV-test · deltakerspor' public-site/current/post-cutover-live.js
           grep -q 'Det er lov å være sliten' public-site/current/n1-feedback-completion.js
           grep -q 'du trenger ikke dele mer personlig' public-site/current/n1-feedback-completion.js
           grep -q 'Valença / Tui' public-site/current/n1-feedback-completion.js
@@ -32,4 +38,4 @@ jobs:
           grep -q 'Santiago er ikke slutten på historien' public-site/current/n1-feedback-completion.js
           grep -q 'En annen vei passer bedre nå' public-site/current/n1-feedback-completion.js
           grep -q 'Én levende plan' public-site/current/n1-feedback-completion.js
-          ! grep -Eqi 'behandler|kurerer|garanterer.*bedring|garanterer.*arbeid' public-site/current/n1-feedback-completion.js
+          ! grep -Eqi 'behandler|kurerer|garanterer.*bedring|garanterer.*arbeid' public-site/current/n1-feedback-completion.js public-site/current/post-cutover-live.js

--- a/.github/workflows/public-n1-runtime-qa.yml
+++ b/.github/workflows/public-n1-runtime-qa.yml
@@ -48,8 +48,13 @@ jobs:
           dump contact-mobile "$BASE/kontakt.html?spor=deltaker&fra=qa#deltaker-interesse" 390
           dump home-desktop "$BASE/index.html" 1440
 
-          grep -q 'Camino Portugués · Portugal → Spania' n1-runtime-qa/home-mobile.html
+          grep -q '<strong>Camino Portugués</strong>' n1-runtime-qa/home-mobile.html
           grep -q 'Målgang, mestring – og en ny begynnelse' n1-runtime-qa/home-mobile.html
+          grep -q 'Oppfølging hjemme' n1-runtime-qa/home-mobile.html
+          grep -q '>72 t<' n1-runtime-qa/home-mobile.html
+          grep -q '>14 d<' n1-runtime-qa/home-mobile.html
+          grep -q '>30 d<' n1-runtime-qa/home-mobile.html
+          grep -q '>90 d<' n1-runtime-qa/home-mobile.html
           grep -q 'Tre steg er hele løpet' <(curl -fsS "$BASE/n1-ux.js")
           grep -q 'n1-route-map' n1-runtime-qa/route-mobile.html
           grep -q 'deltaker-interesse' n1-runtime-qa/contact-mobile.html

--- a/.github/workflows/public-site-smoke.yml
+++ b/.github/workflows/public-site-smoke.yml
@@ -41,6 +41,7 @@ jobs:
           test -f "$ROOT/n1-ux.css"
           test -f "$ROOT/n1-intake-safe.js"
           test -f "$ROOT/n1-feedback-completion.js"
+          test -f "$ROOT/post-cutover-live.js"
           test -f "$ROOT/takk.html"
           test -f "$ROOT/SOURCE_PARITY_MANIFEST_2026-08-18.json"
           grep -q 'naturalContentHeight' "$ROOT/site.js"
@@ -52,15 +53,16 @@ jobs:
           grep -q 'my.AidMe' "$ROOT/site.js"
           grep -q 'n1-ux.js' "$ROOT/site.js"
           grep -q 'n1-feedback-completion.js' "$ROOT/site.js"
+          grep -q 'post-cutover-live.js' "$ROOT/site.js"
           grep -q 'grid-template-columns: 1fr' "$ROOT/mobile-ux.css"
           grep -q 'Gå videre til VIDA' "$ROOT/ser.html"
           grep -q 'Under lading' "$ROOT/via.html"
           grep -q 'n1-intake-safe.js' "$ROOT/kontakt.html"
 
           # Preserve exact known bytes for the verified layered public source.
-          # site.js intentionally changed in the feedback-completion release to
-          # sequence the additive feedback layer after canonical n1-ux.js.
-          test "$(git hash-object "$ROOT/site.js")" = 'fc994876dc3d6e920884b3f2fee4e0244ebd84fc'
+          # site.js now sequences the approved post-cutover layer after canonical N1 UX.
+          test "$(git hash-object "$ROOT/site.js")" = '4dddd0aff213ee9a7863b79ebdcb7711b044dc52'
+          test "$(git hash-object "$ROOT/post-cutover-live.js")" = 'feb494f23f96c1955e841d97d3d764536bf0fa73'
           test "$(git hash-object "$ROOT/mobile-ux.css")" = '9512227a22ba281f94644887c5e723bedb8b02dd'
           test "$(git hash-object "$ROOT/kontakt.html")" = '2f4664cc1a6aca8184c20960c90dafd452d1fecb'
 
@@ -78,7 +80,6 @@ jobs:
 
           for item in manifest.get('files', []):
               rel = item['path']
-              # Layered public UX changes are additive/reversible and explicitly pinned above.
               if rel in layered:
                   continue
               expected_size = int(item['size'])

--- a/public-site/current/post-cutover-live.js
+++ b/public-site/current/post-cutover-live.js
@@ -9,10 +9,14 @@
     const style=document.createElement('style');
     style.id='post-cutover-live-style';
     style.textContent=`
+      .n1-referral-fields[hidden]{display:none!important}
       .n1-arrival-copy .n1-home-rhythm{margin:16px 0 14px;gap:7px;align-items:center}
       .n1-arrival-copy .n1-home-rhythm span{color:#fff;border-color:rgba(200,164,93,.55);background:rgba(255,255,255,.08)}
       .n1-vida-followup-label{margin:4px 0 0;color:var(--gold)!important;font-size:11px!important;font-weight:800;letter-spacing:.08em;text-transform:uppercase}
-      html[data-lang="no"] .n1-milestone .lang-en,html[data-lang="en"] .n1-milestone .lang-no{display:none!important}
+      html[data-lang="no"] .n1-milestone .lang-en{display:none!important}
+      html[data-lang="no"] .n1-milestone .lang-no{display:inline!important}
+      html[data-lang="en"] .n1-milestone .lang-no{display:none!important}
+      html[data-lang="en"] .n1-milestone .lang-en{display:inline!important}
       @media(max-width:650px){
         .three-steps .step{min-height:0;padding:23px 20px 24px}
         .three-steps .step .num{display:block;margin-bottom:5px}
@@ -23,15 +27,25 @@
         .three-steps .step .phase{margin-top:7px}
         .three-steps .step-link{display:inline-flex;margin-top:5px}
         .hero-grid>.camino-clarifier.n1-mobile-after-photo{margin:13px 18px 18px;padding:11px 12px}
-        .n1-milestones{display:grid!important;grid-template-columns:1fr 1fr!important;gap:7px!important;margin:10px 0 17px!important}
-        .n1-milestone{padding:9px 11px!important;border-radius:11px!important;min-height:0!important}
-        .n1-milestone b{font-size:12px!important}
-        .n1-milestone span{font-size:10px!important;line-height:1.3!important;margin-top:2px!important}
+        .route-shell .n1-milestones{display:block;margin:7px 0 18px;padding:0;border-top:1px solid rgba(255,255,255,.16)}
+        .route-shell .n1-milestone{position:relative;padding:8px 0 8px 20px;border:0;border-bottom:1px solid rgba(255,255,255,.13);border-radius:0;background:transparent;color:#dbe5e2}
+        .route-shell .n1-milestone:before{content:'';position:absolute;left:2px;top:15px;width:7px;height:7px;border-radius:50%;background:var(--gold2);box-shadow:0 0 0 3px rgba(229,207,154,.13)}
+        .route-shell .n1-milestone b{display:inline;color:var(--gold2);font-size:12px;margin-right:5px}
+        .route-shell .n1-milestone>span{display:inline;margin:0;font-size:11px;line-height:1.35;color:#dbe5e2}
+        .route-shell .n1-milestone>span>span{display:inline;margin:0;font-size:inherit;line-height:inherit;color:inherit}
+        .route-intro .n1-milestones{display:block;margin:8px 0 17px;padding:0;border-top:1px solid var(--line)}
+        .route-intro .n1-milestone{position:relative;padding:8px 0 8px 20px;border:0;border-bottom:1px solid var(--line);border-radius:0;background:transparent}
+        .route-intro .n1-milestone:before{content:'';position:absolute;left:2px;top:15px;width:7px;height:7px;border-radius:50%;background:var(--gold)}
+        .route-intro .n1-milestone b{display:inline;font-size:12px;margin-right:5px}
+        .route-intro .n1-milestone>span{display:inline;margin:0;font-size:11px;line-height:1.35}
+        .route-intro .n1-milestone>span>span{display:inline;margin:0;font-size:inherit;line-height:inherit;color:inherit}
+        .route-mini{gap:0}
+        .route-mini div{grid-template-columns:34px minmax(0,1fr) auto;gap:8px;padding:9px 0;align-items:baseline}
+        .route-mini div span:last-child{grid-column:auto;font-size:12px;white-space:nowrap;color:#d7e2df}
         .stage-row{padding-top:7px!important;padding-bottom:7px!important}
         .n1-arrival-copy .n1-home-rhythm{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin:12px 0 14px}
         .n1-arrival-copy .n1-home-rhythm span{padding:7px 4px;text-align:center;font-size:11px}
       }
-      @media(max-width:380px){.n1-milestones{grid-template-columns:1fr!important}}
     `;
     document.head.appendChild(style);
   }
@@ -110,30 +124,38 @@
     const inquiry=form.querySelector('[name="inquiry_type"]');
     const referral=inquiry?.value==='REFERRAL';
     const wrap=form.querySelector('.n1-referral-fields');
-    if(wrap) wrap.hidden=!referral;
+    if(wrap){
+      if(wrap.hidden===referral) wrap.hidden=!referral;
+      wrap.setAttribute('aria-hidden',String(!referral));
+    }
     const role=form.querySelector('[name="referral_role"]');
-    if(role){role.required=!!referral;if(!referral) role.value='';}
+    if(role){role.required=!!referral;if(!referral&&role.value) role.value='';}
     const org=form.querySelector('[name="organization_name"]');
-    if(org&&!referral) org.value='';
+    if(org&&!referral&&org.value) org.value='';
+    return referral;
   };
 
   const hardenDevPreview=(form)=>{
     if(!isDev||!form) return;
     ensureDevStructure(form);
     const enforce=()=>{
-      form.dataset.intakeState='dev-preview';
-      form.querySelectorAll('input,select,textarea,button[type="submit"]').forEach(el=>{el.disabled=false;});
+      if(form.dataset.intakeState!=='dev-preview') form.dataset.intakeState='dev-preview';
+      form.querySelectorAll('input,select,textarea,button[type="submit"]').forEach(el=>{if(el.disabled) el.disabled=false;});
       form.querySelector('.n1-turnstile')?.remove();
       const fallback=form.querySelector('.n1-intake-fallback');
-      if(fallback) fallback.hidden=true;
+      if(fallback&&!fallback.hidden) fallback.hidden=true;
+      const referral=syncReferral(form);
       const note=form.querySelector('.n1-form-note');
-      if(note) note.innerHTML='<strong>DEV-test:</strong> Skjemaet kan fylles ut for å teste hele første kontaktflyt, men ingen persondata lagres eller sendes.';
-      syncReferral(form);
+      if(note){
+        note.innerHTML=referral
+          ? '<strong>DEV-test · henviserspor:</strong> Bruk dine egne kontaktopplysninger. Ikke skriv navn, helseopplysninger eller andre private opplysninger om personen du vurderer å henvise. Ingen persondata lagres eller sendes i denne testen.'
+          : '<strong>DEV-test · deltakerspor:</strong> Dette er bare en kort interesse for deg selv. Ingen helseopplysninger trengs her, og ingen persondata lagres eller sendes i denne testen.';
+      }
     };
     enforce();
     if(form.dataset.postCutoverDevBound!=='1'){
       form.dataset.postCutoverDevBound='1';
-      form.addEventListener('change',()=>syncReferral(form));
+      form.addEventListener('change',()=>enforce());
       form.addEventListener('submit',event=>{
         event.preventDefault();
         event.stopImmediatePropagation();
@@ -142,7 +164,7 @@
         location.href='takk.html?devPreview=1';
       },true);
       const observer=new MutationObserver(enforce);
-      observer.observe(form,{subtree:true,childList:true,attributes:true,attributeFilter:['disabled','data-intake-state','hidden']});
+      observer.observe(form,{subtree:true,childList:true,attributes:true,attributeFilter:['disabled']});
     }
   };
 


### PR DESCRIPTION
Follow-up QA patch for MYFB-009 after owner approval to promote the discussed dev changes.

- Matches the exact owner-approved compact route/timeline treatment from PR #82 instead of introducing a new layout.
- Keeps NO/EN milestone text mutually exclusive.
- Keeps concise `Camino Portugués` heading with explanation below.
- Makes the 72 t / 14 d / 30 d / 90 d VIDA follow-up row legible and organized.
- Stabilizes the dev-only no-write interest form preview so fields remain editable without opening production intake.
- Preserves participant vs referral branching and clears referral-only values when switching back to self-interest.
- Production real-data intake remains CLOSED/fail-closed. No Supabase/RLS/consent/role/DNS/Wix changes.