### PR TITLE
Portal: restrict project owner from individual form payloads

### DIFF
--- a/.github/workflows/project-owner-form-scope.yml
+++ b/.github/workflows/project-owner-form-scope.yml
@@ -1,0 +1,35 @@
+name: Project owner form scope QA
+
+on:
+  pull_request:
+    paths:
+      - 'portal/form-runner.js'
+      - 'supabase/migrations/**project_owner_form_scope**.sql'
+      - '.github/workflows/project-owner-form-scope.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  least-privilege:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify project owner cannot inherit individual form payloads
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          form=Path('portal/form-runner.js').read_text()
+          mig=Path('supabase/migrations/20260824012600_project_owner_form_scope_v1.sql').read_text()
+          assert "project_owner:['pilot_go','pilot_evaluation']" in form
+          for key in ['info_before_via','interest_referral','via_roadmap','participant_agreement']:
+              block=mig.split(f"when '{key}' then",1)[1].split("when '",1)[0]
+              assert "manage_program" not in block, (key, block)
+          assert "when 'pilot_go'" in mig and "when 'pilot_evaluation'" in mig
+          policy=mig.split('create policy form_submission_read',1)[1]
+          assert 'view_case_status' not in policy
+          assert 'staff_form_allowed_v2' in policy
+          print('Project owner form scope is least-privilege aligned.')
+          PY

--- a/portal/form-runner.js
+++ b/portal/form-runner.js
@@ -4,7 +4,7 @@ const client=supabase.createClient(SUPABASE_URL,SUPABASE_PUBLISHABLE_KEY);
 const $=s=>document.querySelector(s);
 let session=null,participants=[],pilots=[],pilotParticipants=[],grants=[],definitions=[],versions=[],currentDef=null,currentVersion=null,currentDraft=null;
 const ROLE_KEYS={
- project_owner:['info_before_via','interest_referral','via_roadmap','participant_agreement','pilot_go','pilot_evaluation'],
+ project_owner:['pilot_go','pilot_evaluation'],
  program_lead:['interest_referral','pilot_go'],
  via_owner:['info_before_via','interest_referral','via_roadmap','individual_go_no_go','participant_agreement'],
  clinical_professional:['info_before_via','interest_referral','via_roadmap','individual_go_no_go','participant_agreement'],

--- a/portal/pilot-evaluation-smoke.mjs
+++ b/portal/pilot-evaluation-smoke.mjs
@@ -14,7 +14,8 @@ assert(layer.includes('key=pilot_evaluation&pilot='),'Evaluation entry must carr
 assert(layer.includes('Aggregert læring')&&layer.includes('ikke en ny deltakerport'),'Evaluation UX must be program learning, not a participant gate');
 assert(layer.includes('aggregert lesetilgang')&&layer.includes('manage_program'),'UI must explain the current read/write role boundary in user-facing language');
 assert(!layer.includes('client.from(')&&!layer.includes('functions.invoke('),'Evaluation entry layer must be presentation/navigation only');
-assert(runner.includes("project_owner:['info_before_via','interest_referral','via_roadmap','participant_agreement','pilot_go','pilot_evaluation']"),'Existing form runner must keep pilot_evaluation available to project owner');
+assert(runner.includes("project_owner:['pilot_go','pilot_evaluation']"),'Project owner must retain pilot-level GO/evaluation without inheriting individual participant forms');
+assert(!runner.includes("project_owner:['info_before_via'")&&!runner.includes("project_owner:['interest_referral'")&&!runner.includes("project_owner:['via_roadmap'")&&!runner.includes("project_owner:['participant_agreement'"),'Project owner must not regain individual form payload UI through generic program ownership');
 assert(!runner.includes("evaluator:['pilot_evaluation']")&&!runner.includes("observer:['pilot_evaluation']"),'Do not silently widen evaluator/observer write UI');
 assert(journey.includes('| 11. Evaluering |')&&journey.includes('Aggregert læring → forbedring'),'Implementation must align with the documented evaluation journey');
 assert(journey.includes('Observatør/evaluator har aggregert tilgang som standard'),'Evaluator/observer boundary must remain source-aligned');

--- a/supabase/migrations/20260824012600_project_owner_form_scope_v1.sql
+++ b/supabase/migrations/20260824012600_project_owner_form_scope_v1.sql
@@ -1,0 +1,64 @@
+-- AidMe VIDA: least-privilege hardening for versioned form payloads.
+-- Project owner keeps program-level pilot GO/evaluation, but not individual VÍA/intake/agreement payload access solely via manage_program/view_case_status.
+
+create or replace function aidme_private.staff_form_allowed_v2(
+  p_org uuid,
+  p_participant uuid,
+  p_pilot uuid,
+  p_form_version_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path to 'public', 'pg_temp'
+as $function$
+  select coalesce((
+    select case fd.key
+      when 'info_before_via' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_via')
+      when 'interest_referral' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_via')
+        or aidme_private.has_capability(p_org,p_participant,p_pilot,'manage_tasks')
+      when 'via_roadmap' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_via')
+      when 'individual_go_no_go' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'decide_go')
+      when 'participant_agreement' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_via')
+      when 'pilot_go' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'manage_program')
+        or aidme_private.has_capability(p_org,p_participant,p_pilot,'manage_tasks')
+        or aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_logistics')
+      when 'ser_daily' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_ser')
+      when 'incident' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_incidents')
+      when 'vida_plan' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'edit_vida')
+      when 'pilot_evaluation' then
+        aidme_private.has_capability(p_org,p_participant,p_pilot,'manage_program')
+      else false
+    end
+    from public.form_versions fv
+    join public.form_definitions fd on fd.id=fv.form_definition_id
+    where fv.id=p_form_version_id
+      and fv.published_at is not null
+      and (fv.retired_at is null or fv.retired_at>now())
+  ),false);
+$function$;
+
+comment on function aidme_private.staff_form_allowed_v2(uuid,uuid,uuid,uuid) is
+'Least-privilege form authorization. Individual form payload access follows form-specific capabilities; manage_program is limited to pilot_go and pilot_evaluation.';
+
+-- Do not let the generic case-status capability become a side door to every versioned form payload.
+drop policy if exists form_submission_read on public.form_submissions;
+create policy form_submission_read
+on public.form_submissions
+for select
+to authenticated
+using (
+  ((participant_id is not null) and aidme_private.is_own_participant(participant_id))
+  or submitted_by = (select auth.uid())
+  or aidme_private.staff_form_allowed_v2(organization_id, participant_id, pilot_id, form_version_id)
+);


### PR DESCRIPTION
Q&A/role audit proved a least-privilege mismatch: project_owner has manage_program/view_case_status, and the current form UI/RLS allowed those generic capabilities to expose individual VÍA/intake/agreement payloads. Canonical role scope says project_owner is program/status/reporting, not automatic individual sensitive case access.

This PR:
- limits project_owner form UI to pilot_go + pilot_evaluation;
- removes manage_program as authorization for individual info/intake/VÍA/agreement forms;
- removes generic view_case_status as a read side-door to all form_submissions payloads;
- keeps participant-own access, submitter-own drafts and form-specific staff authorization;
- adds a dedicated least-privilege regression workflow.

Restrictive only: no new role grants, no public intake opening, no AAL2/RLS weakening, no DNS/Wix change. Program-lead/clinical form responsibilities that might require broader access are deliberately not expanded in this patch; those stay as separate VERIFY items.