### PR TITLE
Portal: keep agreement review least-privilege and actionable

### DIFF
--- a/portal/app-go-decision.js
+++ b/portal/app-go-decision.js
@@ -15,11 +15,19 @@ function staffDecisionTaskGate(task,participant){
     local:'participant',
     hint:'Samlet Pilot-GO er registrert. Åpne deltakeren og bruk «Kontroller og start SER»; serveren gjør siste gatekontroll.'
   };
-  if(task.workflow_key==='via_agreement_review')return{
-    label:'Se fullført avtale / beredskap',
-    href:`./form-runner.html?key=participant_agreement&participant=${encodeURIComponent(participant.id)}&latest=1`,
-    hint:'Les deltakerens faktiske avtale, kontakt-/delingsvalg og beredskapsbekreftelser før review lukkes. Deretter er samlet Pilot-GO neste formelle gate; avtalen er ikke i seg selv en SER-godkjenning.'
-  };
+  if(task.workflow_key==='via_agreement_review'){
+    const canReviewAgreement=canContext('edit_via',participant.id,pilot?.id||null);
+    if(!canReviewAgreement)return{
+      label:'Åpne ansvar / avklar reviewer',
+      href:`./owners.html?participant=${encodeURIComponent(participant.id)}`,
+      hint:'Du kan koordinere programramme og neste gate, men detaljert deltakeravtale er rollebegrenset. Tildel eller involver autorisert VÍA-/fagrolle for detaljreview i stedet for å utvide sensitiv tilgang som snarvei.'
+    };
+    return{
+      label:'Se fullført avtale / beredskap',
+      href:`./form-runner.html?key=participant_agreement&participant=${encodeURIComponent(participant.id)}&latest=1`,
+      hint:'Les deltakerens faktiske avtale, kontakt-/delingsvalg og beredskapsbekreftelser før review lukkes. Deretter er samlet Pilot-GO neste formelle gate; avtalen er ikke i seg selv en SER-godkjenning.'
+    };
+  }
   return{
     label:'Åpne avtale / beredskap',
     href:`./form-runner.html?key=participant_agreement&participant=${encodeURIComponent(participant.id)}`,

--- a/portal/go-decision-journey-smoke.mjs
+++ b/portal/go-decision-journey-smoke.mjs
@@ -7,6 +7,7 @@ const participant=read('./app-participant.js');
 const participantNext=read('./app-participant-next.js');
 const ops=read('./app-ops.js');
 const staffRouting=read('./app-go-decision.js');
+const runner=read('./form-runner.js');
 const build=read('./build-app.mjs');
 const workflow=read('../supabase/functions/workflow-command/index.ts');
 const decisionMigration=read('../supabase/migrations/20260822023000_go_decision_participant_handoff_v1.sql');
@@ -43,7 +44,12 @@ assert(participantNext.includes("stage==='POSTPONED'||stage==='NO_GO'"),'Postpon
 assert(ops.includes("p.stage==='POSTPONED'"),'Staff must be able to reopen a postponed case for a new formal decision');
 assert(ops.includes('PARTICIPANT_AGREEMENT_REQUIRED'),'Staff SER gate must explain agreement blocking condition');
 assert(ops.includes('Avtale / beredskap'),'Staff GO surface must expose agreement/readiness before SER');
-assert(staffRouting.includes("task.workflow_key==='via_agreement_review'"),'Agreement review task must route onward to Pilot-GO');
+assert(staffRouting.includes("task.workflow_key==='via_agreement_review'"),'Agreement review task must route onward safely');
+assert(staffRouting.includes("canContext('edit_via',participant.id"),'Detailed agreement review must follow the existing sensitive VÍA capability rather than generic program status access');
+assert(staffRouting.includes('Åpne ansvar / avklar reviewer'),'A staff member without detailed agreement scope must get a safe owner/reviewer path instead of a broken sensitive form link');
+assert(staffRouting.includes('i stedet for å utvide sensitiv tilgang som snarvei'),'Agreement review UX must explain the least-privilege boundary');
+assert(runner.includes("program_lead:['interest_referral','pilot_go']"),'Program lead must not gain participant_agreement form access as a shortcut');
+assert(!runner.includes("program_lead:['interest_referral','participant_agreement'"),'Do not silently widen program lead sensitive agreement access');
 assert(staffRouting.includes("task.workflow_key==='ser_start_ready'"),'Pilot-GO handoff task must route to last SER control');
 assert(build.includes("app-go-decision.js")&&build.includes("+goDecision+"),'GO decision extension must be part of the production bundle');
 


### PR DESCRIPTION
Active malpakke assigns participant agreement to participant + program responsibility, while current sensitive form scope deliberately keeps `participant_agreement` under `edit_via` and does not grant it to generic `program_lead`.

A `via_agreement_review` task can still fall back to program lead. Previously its task shortcut always linked directly to the sensitive agreement form, producing a broken/unauthorised route and tempting a broad rights expansion.

This PR fixes the flow without widening access:
- detailed agreement review link is shown only when existing `edit_via` scope covers the participant/pilot;
- otherwise staff gets a clear `Åpne ansvar / avklar reviewer` route;
- copy states that program coordination does not imply sensitive agreement access;
- regression checks lock that `program_lead` does not silently gain participant_agreement form access.

No RLS, role grant, capability, AAL2, consent or data scope is expanded. A future dedicated read-only agreement-review capability remains a separate explicit security/scope decision if the owner later wants it.