### PR TITLE
Portal: keep project owner out of SER→VIDA transition UI

### DIFF
--- a/portal/app-ser-vida-handoff.js
+++ b/portal/app-ser-vida-handoff.js
@@ -10,7 +10,7 @@ const SER_VIDA_HANDOFF_ERRORS={
   STALE_STAGE:'Fasen ble endret et annet sted. Last arbeidsflaten på nytt.'
 };
 function serVidaHandoffError(code){return SER_VIDA_HANDOFF_ERRORS[code]||'VIDA kunne ikke startes. Ingen alternativ direkte databasevei ble brukt.'}
-function canStartVida(){return hasRole('project_owner')||hasRole('program_lead')||hasRole('ser_lead')}
+function canStartVida(){return hasRole('program_lead')||hasRole('ser_lead')}
 function serVidaHandoffParticipant(){return canStartVida()?participantById(selectedParticipantId):null}
 function serVidaHandoffOpenSerTasks(p){return (tasks||[]).filter(t=>t.participant_id===p?.id&&['OPEN','IN_PROGRESS','WAITING'].includes(t.status)&&String(t.workflow_key||'').startsWith('ser_'))}
 

--- a/portal/ser-vida-handoff-smoke.mjs
+++ b/portal/ser-vida-handoff-smoke.mjs
@@ -8,7 +8,7 @@ const ops=read('./app-ops.js');
 const build=read('./build-app.mjs');
 
 assert(build.includes("app-ser-vida-handoff.js")&&build.includes("'+serVidaHandoff+'"),'SER→VIDA handoff layer must be included in deterministic portal build');
-assert(layer.includes("hasRole('project_owner')")&&layer.includes("hasRole('program_lead')")&&layer.includes("hasRole('ser_lead')"),'SER→VIDA control must be hidden from staff roles without a matching transition capability');
+assert(!layer.includes("hasRole('project_owner')")&&layer.includes("hasRole('program_lead')")&&layer.includes("hasRole('ser_lead')"),'SER→VIDA control must stay hidden from project_owner and remain available only to operational transition roles');
 assert(layer.includes("p.stage!=='SER'")||layer.includes("p.stage==='SER'"),'SER→VIDA action must be stage constrained');
 assert(layer.includes("client.functions.invoke('workflow-command'")&&layer.includes("action:'START_VIDA'"),'Transition must use the existing workflow command and START_VIDA action');
 assert(!layer.includes('client.from('),'Handoff layer must not add direct database writes');
@@ -18,4 +18,4 @@ assert(layer.includes('ikke automatisk')&&layer.includes('åpne SER-oppgave'),'H
 assert(layer.includes('window.confirm'),'Stage transition must require an explicit staff confirmation click');
 assert(ops.includes("p.stage==='SER'||p.stage==='VIDA'")&&!ops.includes("action='START_VIDA'")&&!ops.includes("action='START_NEW_VIA'"),'Generic ops layer must not render duplicate SER/VIDA transition controls');
 
-console.log('SER→VIDA explicit staff handoff and dedupe invariants OK');
+console.log('SER→VIDA explicit staff handoff, project-owner least-privilege and dedupe invariants OK');


### PR DESCRIPTION
## Why
The canonical role journey keeps `project_owner` at program/reporting level without automatic individual case access. The SER→VIDA client layer nevertheless rendered the individual transition control for `project_owner`.

## Change
- Remove `project_owner` from the client-side SER→VIDA transition control.
- Keep `program_lead` and `ser_lead` unchanged.
- Add a regression assertion that the shortcut stays hidden from `project_owner`.

## Security boundary
This is a least-privilege UI narrowing only. It does not change roles/scopes, RLS, AAL2, consent, Supabase production functions, real-data intake, DNS, or any backend authorization. The broader `workflow-command` capability gate remains VERIFY and is intentionally not changed in this PR.

## QA
Run the existing SER→VIDA handoff smoke plus portal smoke / relevant CI before merge.