### PR TITLE
Portal SER/VIDA: streamline provenance across participant, staff and partner

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -106,3 +106,5 @@ jobs:
         run: node portal/pilot-evaluation-smoke.mjs
       - name: Verify semantic navigation badge invariants
         run: node portal/nav-badges-smoke.mjs
+      - name: Verify SER and VIDA streamline provenance invariants
+        run: node portal/form-streamline-provenance-smoke.mjs

--- a/portal/STREAMLINE_ROLE_FLOW_2026-08-24.md
+++ b/portal/STREAMLINE_ROLE_FLOW_2026-08-24.md
@@ -1,0 +1,36 @@
+# Strømlinjet rolleflyt — deltaker · ansatt · partner
+
+Dato: 2026-08-24
+Status: aktiv arbeidsregel for portalens videre UX/arbeidsflyt
+
+## Grunnregel
+
+Én opplysning eller handling registreres ved sin riktige kilde én gang. Senere roller får en rolleavgrenset visning eller handoff av samme kontekst når det er nødvendig; de skal ikke be om eller kopiere samme historie på nytt.
+
+## SER-kjeden
+
+| Kilde / rolle | Registrerer | Skal ikke gjøre |
+|---|---|---|
+| Deltaker | Kort egeninnsjekk i `ser_checkins`; egne ord og egen opplevelse | Fylle teamets operative SER-logg eller klassifisere egen dagsform som hendelse |
+| Operativ ansatt / SER-leder | `ser_daily`: observerbare fakta, rute/tilpasning, tiltak, ansvar og nødvendig oppfølging | Kopiere deltakerens fritekst eller gjøre normal belastning/pause til avvik |
+| Operativ ansatt ved faktisk hendelse | `incident`: fakta, umiddelbar risiko, tiltak/varsling, eier og lukking | Bruke hendelseslogg som ekstra normaldagslogg |
+| VIDA-eier / relevant partner | `vida_plan`: avtalt handling, støtte/eier, frist og oppfølging hjemme | Kopiere rå SER-notater, private refleksjoner eller hendelsesdetaljer uten behov |
+| Evaluator / prosjekt | `pilot_evaluation`: aggregert sikkerhet, erfaring, ressursbruk og læring | Opprette en ny individuell deltakerjournal |
+
+## Partner betyr ikke bred generell tilgang
+
+Det opprettes ikke en generell `partner`-rolle som snarvei. Eksterne aktører får eksisterende, navngitt rolle og nødvendig scope, for eksempel `vida_owner`, `evaluator` eller annen eksplisitt funksjon. RLS/AAL2 og rolle-/pilot-/deltakerscope er fortsatt autoritativt.
+
+## UX-regler fremover
+
+1. Vis kilden tydelig: «deltakerens egen innsjekk», «teamets operative vurdering», «VIDA-handoff» eller «aggregert evaluering».
+2. Gjenbruk status og kontekst read-only der det sparer dobbelføring.
+3. Ikke gjenbruk fritekst automatisk mellom rolleflater.
+4. Hendelseslogg åpnes bare ved reell hendelse/avvik.
+5. VIDA forblir én levende plan gjennom 72t/14d/30d/90d.
+6. Partner-/evaluatorflater skal som standard vise mindre, ikke mer, enn operative interne flater.
+7. Nye felter eller skjema må begrunnes med en informasjonskilde som ikke allerede finnes.
+
+## Gjeldende implementering
+
+`form-streamline-provenance.js` legger et read-only provenance-/arbeidsflytlag over eksisterende skjema. For `ser_daily` hentes kun siste `checkin_date` og `rag` fra eksisterende `ser_checkins` gjennom dagens RLS. Deltakerens `participant_note` hentes ikke. Laget har ingen insert/update/upsert/delete og endrer ingen schema-, RLS- eller rolledefinisjoner.

--- a/portal/form-qna-guidance.js
+++ b/portal/form-qna-guidance.js
@@ -52,3 +52,10 @@ if(originalChooseForm){
 document.querySelector('#formSelect')?.addEventListener('change',()=>setTimeout(renderFormQnaGuidance,0));
 setTimeout(renderFormQnaGuidance,160);
 })();
+
+if(!document.querySelector('script[data-form-streamline-provenance]')){
+  const script=document.createElement('script');
+  script.src='./form-streamline-provenance.js?v=20260824a';
+  script.dataset.formStreamlineProvenance='1';
+  document.body.appendChild(script);
+}

--- a/portal/form-streamline-provenance-smoke.mjs
+++ b/portal/form-streamline-provenance-smoke.mjs
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+
+const src=fs.readFileSync(new URL('./form-streamline-provenance.js',import.meta.url),'utf8');
+const loader=fs.readFileSync(new URL('./form-qna-guidance.js',import.meta.url),'utf8');
+const must=(text,needle,label)=>{if(!text.includes(needle))throw new Error(`${label}: missing ${needle}`)};
+
+must(loader,'form-streamline-provenance.js?v=20260824a','streamline loader');
+must(src,".from('ser_checkins')",'existing participant self-report source');
+must(src,".select('checkin_date,rag')",'minimal read-only check-in projection');
+must(src,"key==='ser_daily'",'staff daily-log boundary');
+must(src,"key==='incident'",'incident-only lane');
+must(src,"key==='vida_plan'",'VIDA handoff lane');
+must(src,"key==='pilot_evaluation'",'aggregated evaluation lane');
+must(src,"streamlineHasRole('vida_owner')",'VIDA owner/partner perspective');
+must(src,'Dette er et signal – ikke tekst som skal kopieres inn i teamloggen.','no duplicate participant narrative');
+must(src,'Vanlig slitenhet eller en legitim pause er ikke automatisk et avvik.','normal adaptation boundary');
+must(src,'Rå SER-notater, hendelsesdetaljer og private refleksjoner skal ikke kopieres','partner minimization boundary');
+if(src.includes('participant_note'))throw new Error('streamline layer must not fetch participant free-text');
+if(/\.(insert|update|upsert|delete)\s*\(/.test(src))throw new Error('streamline layer must remain read-only');
+console.log('SER/VIDA streamline provenance invariants passed.');

--- a/portal/form-streamline-provenance.js
+++ b/portal/form-streamline-provenance.js
@@ -1,0 +1,104 @@
+(()=>{
+'use strict';
+
+let provenanceRequest=0;
+
+function streamlineActiveFormKey(){
+  try{return currentDef?.key||new URLSearchParams(location.search).get('key')||''}catch{return new URLSearchParams(location.search).get('key')||''}
+}
+function streamlineActiveGrant(g){
+  const now=new Date();
+  return !g?.revoked_at&&(!g.valid_from||new Date(g.valid_from)<=now)&&(!g.valid_until||new Date(g.valid_until)>now);
+}
+function streamlineHasRole(code){return (grants||[]).some(g=>streamlineActiveGrant(g)&&g.role_code===code)}
+function streamlineParticipantId(){
+  try{return selectedParticipant()?.id||ownParticipant()?.id||null}catch{return null}
+}
+function streamlineHost(){
+  let host=document.querySelector('#formStreamlineGuidance');
+  if(host)return host;
+  const qna=document.querySelector('#formQnaGuidance');
+  if(!qna)return null;
+  host=document.createElement('article');
+  host.id='formStreamlineGuidance';
+  host.className='panel-card streamline-guidance hidden';
+  host.setAttribute('aria-live','polite');
+  qna.insertAdjacentElement('afterend',host);
+  return host;
+}
+function streamlineStyle(){
+  if(document.querySelector('#form-streamline-style'))return;
+  const style=document.createElement('style');
+  style.id='form-streamline-style';
+  style.textContent=`
+    .streamline-guidance{margin:14px 0;padding:16px 18px;border-left:4px solid #c8a45d;background:#fbf8ef}
+    .streamline-guidance h3{margin:.15rem 0 .45rem}.streamline-guidance p{margin:.35rem 0}
+    .streamline-lanes{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:12px 0}
+    .streamline-lane{padding:10px 12px;border:1px solid rgba(18,63,61,.15);border-radius:12px;background:#fff}
+    .streamline-lane span{display:block;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:#62706f}.streamline-lane b{display:block;margin-top:3px}
+    .streamline-actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}.streamline-actions a{display:inline-flex;text-decoration:none}
+    @media(max-width:700px){.streamline-lanes{grid-template-columns:1fr}.streamline-guidance{padding:14px}}
+  `;
+  document.head.appendChild(style);
+}
+function streamlinePill(rag){
+  const value=String(rag||'').toUpperCase();
+  if(value==='RED')return'Rød';if(value==='YELLOW')return'Gul';if(value==='GREEN')return'Grønn';return'Ikke satt';
+}
+function streamlineLink(key,label,participantId){
+  const p=participantId?`&participant=${encodeURIComponent(participantId)}`:'';
+  return `<a class="ghost link-btn" href="./form-runner.html?key=${encodeURIComponent(key)}${p}">${esc(label)}</a>`;
+}
+function streamlineBaseLanes(){
+  return `<div class="streamline-lanes"><div class="streamline-lane"><span>Deltaker</span><b>Egne ord / egen innsjekk</b></div><div class="streamline-lane"><span>Ansatt</span><b>Operativt minimum</b></div><div class="streamline-lane"><span>Partner / VIDA</span><b>Kun avtalt handoff</b></div></div>`;
+}
+async function streamlineLatestCheckin(participantId){
+  if(!participantId)return null;
+  const {data,error}=await client.from('ser_checkins')
+    .select('checkin_date,rag')
+    .eq('participant_id',participantId)
+    .order('checkin_date',{ascending:false})
+    .limit(1)
+    .maybeSingle();
+  return error?null:data||null;
+}
+async function renderFormStreamlineGuidance(){
+  const host=streamlineHost();if(!host)return;
+  streamlineStyle();
+  const key=streamlineActiveFormKey(),participantId=streamlineParticipantId(),request=++provenanceRequest;
+  if(!['ser_daily','incident','vida_plan','pilot_evaluation'].includes(key)){
+    host.classList.add('hidden');host.innerHTML='';return;
+  }
+  host.classList.remove('hidden');
+  if(key==='ser_daily'){
+    host.innerHTML=`<p class="eyebrow">Én registrering · riktig kilde</p><h3>SER-dagsbildet skal ikke dobbelregistreres</h3>${streamlineBaseLanes()}<p>Laster deltakerens siste egeninnsjekk som read-only signal …</p>`;
+    const checkin=await streamlineLatestCheckin(participantId);if(request!==provenanceRequest)return;
+    const signal=checkin?`${esc(checkin.checkin_date)} · ${esc(streamlinePill(checkin.rag))}`:'Ingen egeninnsjekk funnet';
+    host.innerHTML=`<p class="eyebrow">Én registrering · riktig kilde</p><h3>SER-dagsbildet skal ikke dobbelregistreres</h3>${streamlineBaseLanes()}<p><strong>Deltakerens egen innsjekk:</strong> ${signal}. Dette er et signal – ikke tekst som skal kopieres inn i teamloggen.</p><p><strong>Teamets ansvar her:</strong> før bare observérbare fakta, rute/tilpasning, tiltak, ansvar og nødvendig oppfølging. Vanlig slitenhet eller en legitim pause er ikke automatisk et avvik.</p><div class="streamline-actions">${streamlineLink('incident','Reell hendelse/avvik →',participantId)}</div>`;
+    return;
+  }
+  if(key==='incident'){
+    host.innerHTML=`<p class="eyebrow">Hendelse · bare ved behov</p><h3>Ikke gjør normal SER til avviksrapportering</h3>${streamlineBaseLanes()}<p>Bruk denne loggen bare når noe faktisk er en hendelse eller et avvik. Beskriv observerbare fakta, umiddelbar risiko, tiltak/varsling og hvem som lukker oppfølgingen. Ikke kopier deltakerens private refleksjoner.</p><div class="streamline-actions">${streamlineLink('ser_daily','Til normal SER-operativlogg →',participantId)}</div>`;
+    return;
+  }
+  if(key==='vida_plan'){
+    const staff=typeof isStaff==='function'&&isStaff();
+    const owner=streamlineHasRole('vida_owner');
+    const heading=staff?(owner?'VIDA-eier: overta handling, ikke historikken':'VIDA-handoff: bare det som trengs videre'):'Din levende VIDA-plan';
+    const body=staff?'Overfør avtalte handlinger, støtte/eier og frister som er nødvendige hjemme. Rå SER-notater, hendelsesdetaljer og private refleksjoner skal ikke kopieres bare fordi de finnes.':'Dette er samme levende plan gjennom 72 timer, 14, 30 og 90 dager. Oppdater neste handling her – ikke lag nye parallelle planer.';
+    host.innerHTML=`<p class="eyebrow">SER → VIDA · minst mulig dobbelføring</p><h3>${esc(heading)}</h3>${streamlineBaseLanes()}<p>${esc(body)}</p>`;
+    return;
+  }
+  if(key==='pilot_evaluation'){
+    host.innerHTML=`<p class="eyebrow">Evaluering · aggregert læring</p><h3>Lær av piloten uten å lage en ny deltakerjournal</h3>${streamlineBaseLanes()}<p>Bruk aggregert sikkerhet, erfaring, ressursbruk og forbedringspunkter. Individuelle SER-notater og private refleksjoner skal ikke kopieres inn når aggregert læring er tilstrekkelig.</p>`;
+  }
+}
+
+const streamlineChooseForm=typeof chooseForm==='function'?chooseForm:null;
+if(streamlineChooseForm){
+  chooseForm=async function(...args){const result=await streamlineChooseForm.apply(this,args);await renderFormStreamlineGuidance();return result};
+}
+document.querySelector('#participantSelect')?.addEventListener('change',()=>setTimeout(renderFormStreamlineGuidance,20));
+document.querySelector('#formSelect')?.addEventListener('change',()=>setTimeout(renderFormStreamlineGuidance,20));
+setTimeout(renderFormStreamlineGuidance,220);
+})();


### PR DESCRIPTION
Implements the owner-requested streamline principle across participant → employee → partner without new schema or broader access.

Behavior:
- participant self-check-in remains the source of the participant's own daily signal (`ser_checkins`);
- `ser_daily` shows only latest check-in date/RAG read-only, never participant free-text, so staff do not copy the participant narrative;
- daily SER staff log remains operational minimum: observable facts, route/adaptation, action, owner and necessary follow-up;
- incident is explicitly separated and linked only for real events/deviations;
- VIDA owner/relevant partner gets handoff/action guidance, not raw SER notes/private reflections;
- pilot evaluation is framed as aggregated learning, not a new individual journal;
- documents the standing streamline rule and explicitly rejects a broad generic `partner` role shortcut.

Security/data boundaries:
- no schema, migration, RLS, AAL2, role grant, backend function, intake or DNS changes;
- new Supabase use is read-only SELECT through existing RLS;
- only `checkin_date,rag` are selected; `participant_note` is deliberately not fetched;
- streamline layer contains no insert/update/upsert/delete.

Based on active SharePoint malpakke principle: basic information once, one short SER operational log, incident only for actual incident/deviation, one living VIDA plan.