### PR TITLE
Portal: make analysis graphs readable and explicit on mobile

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -108,3 +108,5 @@ jobs:
         run: node portal/nav-badges-smoke.mjs
       - name: Verify SER and VIDA streamline provenance invariants
         run: node portal/form-streamline-provenance-smoke.mjs
+      - name: Verify analysis clarity and mobile readability invariants
+        run: node portal/analysis-clarity-smoke.mjs

--- a/portal/analysis-clarity-smoke.mjs
+++ b/portal/analysis-clarity-smoke.mjs
@@ -13,7 +13,7 @@ must('ResizeObserver','responsive chart redraw');
 must('orientationchange','mobile orientation redraw');
 must('ANALYSIS_DASHES','series identity beyond color');
 must("Math.min(2.5,Math.max(1,window.devicePixelRatio||1))",'bounded high-DPI rendering');
-if(/client\.from\(|client\.functions\.invoke|\.(insert|update|upsert|delete)\s*\(/.test(src))throw new Error('analysis clarity layer must remain presentation-only and read-only');
+if(src.includes('client.'))throw new Error('analysis clarity layer must not access Supabase/client APIs; it is presentation-only');
 if(src.includes('participant_note'))throw new Error('analysis clarity must not expose participant free-text');
 if(!build.includes("app-analysis-ux.js")||!build.includes("'+analysisUx+'"))throw new Error('analysis clarity layer must be included in deterministic portal build');
 console.log('Portal analysis clarity/readability invariants passed.');

--- a/portal/analysis-clarity-smoke.mjs
+++ b/portal/analysis-clarity-smoke.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+
+const src=fs.readFileSync(new URL('./app-analysis-ux.js',import.meta.url),'utf8');
+const build=fs.readFileSync(new URL('./build-app.mjs',import.meta.url),'utf8');
+const must=(needle,label)=>{if(!src.includes(needle))throw new Error(`${label}: missing ${needle}`)};
+
+must('Ingen registrerte målinger i valgt periode.','explicit all-empty state');
+must('De valgte deltakerne har ingen målinger','explicit selected-empty state');
+must('analysisLegend','external readable legend');
+must('analysis-chip-count','per-participant data availability');
+must('Grafen lager ikke kunstige eller interpolerte verdier.','no fabricated data message');
+must('ResizeObserver','responsive chart redraw');
+must('orientationchange','mobile orientation redraw');
+must('ANALYSIS_DASHES','series identity beyond color');
+must("Math.min(2.5,Math.max(1,window.devicePixelRatio||1))",'bounded high-DPI rendering');
+if(/client\.from\(|client\.functions\.invoke|\.(insert|update|upsert|delete)\s*\(/.test(src))throw new Error('analysis clarity layer must remain presentation-only and read-only');
+if(src.includes('participant_note'))throw new Error('analysis clarity must not expose participant free-text');
+if(!build.includes("app-analysis-ux.js")||!build.includes("'+analysisUx+'"))throw new Error('analysis clarity layer must be included in deterministic portal build');
+console.log('Portal analysis clarity/readability invariants passed.');

--- a/portal/app-analysis-ux.js
+++ b/portal/app-analysis-ux.js
@@ -1,0 +1,78 @@
+(()=>{
+'use strict';
+
+const ANALYSIS_COLORS=['#0b4f4a','#8a5b00','#285c86','#8a3f3b','#3f6f62','#654b75'];
+const ANALYSIS_DASHES=[[],[9,5],[3,4],[11,4,3,4],[7,3],[2,3]];
+let analysisResizeWidth=0,analysisResizeFrame=0;
+
+function analysisEnsureUx(){
+  const canvas=document.querySelector('#analysisChart');
+  const frame=canvas?.parentElement;
+  if(!canvas||!frame)return null;
+  let state=document.querySelector('#analysisState');
+  if(!state){state=document.createElement('div');state.id='analysisState';state.className='analysis-state hidden';state.setAttribute('role','status');state.setAttribute('aria-live','polite');frame.insertAdjacentElement('beforebegin',state)}
+  let meta=document.querySelector('#analysisMeta');
+  if(!meta){meta=document.createElement('p');meta.id='analysisMeta';meta.className='analysis-meta';state.insertAdjacentElement('beforebegin',meta)}
+  let legend=document.querySelector('#analysisLegend');
+  if(!legend){legend=document.createElement('div');legend.id='analysisLegend';legend.className='analysis-legend';frame.insertAdjacentElement('afterend',legend)}
+  if(!document.querySelector('#analysis-clarity-style')){
+    const style=document.createElement('style');style.id='analysis-clarity-style';style.textContent=`
+      .analysis-meta{margin:8px 0 10px;color:#45545b;font-size:12px;font-weight:650}
+      .analysis-state{margin:8px 0 12px;padding:13px 14px;border:1px solid #d4c59f;border-radius:14px;background:#fffaf0;color:#4d493f;font-size:13px;line-height:1.45}
+      .analysis-state strong{display:block;color:#14212b;margin-bottom:3px}
+      .analysis-legend{display:flex;gap:8px 14px;flex-wrap:wrap;margin-top:12px;padding-top:10px;border-top:1px solid #dedbd2}
+      .analysis-legend-item{display:flex;align-items:center;gap:7px;min-width:0;font-size:12px;color:#29373e;font-weight:700}
+      .analysis-legend-line{display:inline-block;width:28px;flex:0 0 28px;border-top-width:3px;border-top-color:currentColor}
+      #analysisParticipants .chip{display:inline-flex;align-items:center;gap:6px}
+      #analysisParticipants .chip[data-has-data="false"]{opacity:.58}
+      #analysisParticipants .chip .analysis-chip-count{font-size:9px;font-weight:850;opacity:.8}
+      .analysis-card .chart-frame{min-height:300px;background:#fffdf8;border:1px solid #dedbd2;border-radius:16px;padding:6px;overflow:hidden}
+      @media(max-width:700px){.analysis-card{padding:16px}.analysis-controls{grid-template-columns:1fr 1fr}.analysis-controls .toggle-label{grid-column:1/-1}.analysis-card .chart-frame{height:312px;min-height:312px}.analysis-legend-item{font-size:11px}}
+    `;document.head.appendChild(style)
+  }
+  return{canvas,frame,state,meta,legend};
+}
+function analysisDateLabel(value){
+  const d=new Date(`${value}T00:00:00`);if(Number.isNaN(d.getTime()))return String(value||'');
+  return new Intl.DateTimeFormat('nb-NO',{day:'2-digit',month:'2-digit'}).format(d);
+}
+function analysisDrawReadable(canvas,series){
+  const frame=canvas.parentElement,rect=frame.getBoundingClientRect();
+  const w=Math.max(280,Math.floor(rect.width-12)),h=window.innerWidth<=700?300:360,dpr=Math.min(2.5,Math.max(1,window.devicePixelRatio||1));
+  canvas.width=Math.round(w*dpr);canvas.height=Math.round(h*dpr);canvas.style.width='100%';canvas.style.height=`${h}px`;
+  const ctx=canvas.getContext('2d');ctx.setTransform(dpr,0,0,dpr,0,0);ctx.clearRect(0,0,w,h);
+  const pad={l:38,r:14,t:16,b:34},cw=Math.max(1,w-pad.l-pad.r),ch=Math.max(1,h-pad.t-pad.b);
+  ctx.font='600 11px system-ui';ctx.textBaseline='middle';ctx.textAlign='right';
+  for(let tick=0;tick<=10;tick+=2){const py=pad.t+ch*(1-tick/10);ctx.strokeStyle=tick===0||tick===10?'#aeb7b4':'#d2d7d4';ctx.lineWidth=1;ctx.beginPath();ctx.moveTo(pad.l,py);ctx.lineTo(w-pad.r,py);ctx.stroke();ctx.fillStyle='#3e4e55';ctx.fillText(String(tick),pad.l-8,py)}
+  const dates=[...new Set(series.flatMap(s=>s.values.map(v=>v.date)))].sort();if(!dates.length)return;
+  const x=d=>pad.l+(dates.length===1?cw/2:cw*dates.indexOf(d)/(dates.length-1)),y=v=>pad.t+ch*(1-Math.max(0,Math.min(10,Number(v)))/10);
+  series.forEach((s,i)=>{const color=s.color||ANALYSIS_COLORS[i%ANALYSIS_COLORS.length],dash=s.dashed?[8,5]:ANALYSIS_DASHES[i%ANALYSIS_DASHES.length];ctx.strokeStyle=color;ctx.lineWidth=s.dashed?2.7:3.2;ctx.lineJoin='round';ctx.lineCap='round';ctx.setLineDash(dash);ctx.beginPath();s.values.forEach((v,j)=>{const px=x(v.date),py=y(v.value);j?ctx.lineTo(px,py):ctx.moveTo(px,py)});ctx.stroke();ctx.setLineDash([]);s.values.forEach(v=>{const px=x(v.date),py=y(v.value);ctx.fillStyle='#fffdf8';ctx.beginPath();ctx.arc(px,py,5.5,0,Math.PI*2);ctx.fill();ctx.fillStyle=color;ctx.beginPath();ctx.arc(px,py,3.7,0,Math.PI*2);ctx.fill()})});
+  const labelIdx=dates.length<=2?dates.map((_,i)=>i):[0,Math.floor((dates.length-1)/2),dates.length-1];ctx.textBaseline='alphabetic';ctx.fillStyle='#3e4e55';ctx.font='600 10px system-ui';labelIdx.forEach((idx,pos)=>{ctx.textAlign=pos===0?'left':pos===labelIdx.length-1?'right':'center';ctx.fillText(analysisDateLabel(dates[idx]),x(dates[idx]),h-8)})
+}
+function analysisAverage(selected){
+  const dates=[...new Set(selected.flatMap(s=>s.values.map(v=>v.date)))].sort();
+  return dates.map(date=>{const vals=selected.flatMap(s=>s.values.filter(v=>v.date===date).map(v=>v.value)).filter(Number.isFinite);return vals.length?{date,value:vals.reduce((a,b)=>a+b,0)/vals.length}:null}).filter(Boolean)
+}
+function renderReadableAnalysis(){
+  const ux=analysisEnsureUx();if(!ux)return;
+  const metric=document.querySelector('#analysisMetric')?.value||'agency',days=Number(document.querySelector('#analysisPeriod')?.value||30),all=participantSeries(metric,days).map((s,i)=>({...s,color:ANALYSIS_COLORS[i%ANALYSIS_COLORS.length]}));
+  if(!analysisSelected.size&&all.length)all.slice(0,3).forEach(s=>analysisSelected.add(s.id));
+  const byId=new Map(all.map(s=>[s.id,s]));
+  document.querySelector('#analysisParticipants').innerHTML=participants.map(p=>{const count=byId.get(p.id)?.values.length||0;return `<button class="chip ${analysisSelected.has(p.id)?'active':''}" type="button" aria-pressed="${analysisSelected.has(p.id)}" data-analysis-id="${p.id}" data-has-data="${count>0}">${escapeHtml(p.code_name)} <span class="analysis-chip-count">${count}</span></button>`}).join('');
+  document.querySelectorAll('[data-analysis-id]').forEach(button=>button.addEventListener('click',()=>{const id=button.dataset.analysisId;analysisSelected.has(id)?analysisSelected.delete(id):analysisSelected.add(id);renderReadableAnalysis()}));
+  const selected=all.filter(s=>analysisSelected.has(s.id)),pointCount=selected.reduce((n,s)=>n+s.values.length,0),metricLabel=document.querySelector('#analysisMetric')?.selectedOptions?.[0]?.textContent||'måling';
+  ux.meta.textContent=`${metricLabel} · ${days} dager · ${selected.length} deltaker${selected.length===1?'':'e'} · ${pointCount} datapunkt${pointCount===1?'':'er'}`;
+  if(!all.length){ux.state.innerHTML='<strong>Ingen registrerte målinger i valgt periode.</strong>Prøv en lengre periode eller en annen måling. Grafen lager ikke kunstige eller interpolerte verdier.';ux.state.classList.remove('hidden');ux.legend.innerHTML='';analysisDrawReadable(ux.canvas,[]);return}
+  if(!selected.length){ux.state.innerHTML='<strong>De valgte deltakerne har ingen målinger for dette valget.</strong>Velg en deltaker med et tall ved navnet, eller endre måling/periode.';ux.state.classList.remove('hidden');ux.legend.innerHTML='';analysisDrawReadable(ux.canvas,[]);return}
+  ux.state.classList.add('hidden');
+  let plotted=[...selected];if(document.querySelector('#showAverage')?.checked){const avg=analysisAverage(selected);if(avg.length)plotted.push({label:'Gruppesnitt',color:'#111820',dashed:true,values:avg})}
+  analysisDrawReadable(ux.canvas,plotted);
+  ux.legend.innerHTML=plotted.map((s,i)=>{const dashed=s.dashed?'dashed':'solid',count=s.values.length;return `<span class="analysis-legend-item"><i class="analysis-legend-line" style="color:${s.color};border-top-style:${dashed}"></i><span>${escapeHtml(s.label)} <small>(${count})</small></span></span>`}).join('');
+}
+
+renderAnalysis=renderReadableAnalysis;
+['analysisMetric','analysisPeriod','showAverage'].forEach(id=>document.querySelector(`#${id}`)?.addEventListener('change',()=>setTimeout(renderReadableAnalysis,0)));
+window.addEventListener('orientationchange',()=>setTimeout(renderReadableAnalysis,120));
+if('ResizeObserver'in window){const frame=document.querySelector('#analysisChart')?.parentElement;if(frame)new ResizeObserver(entries=>{const width=Math.round(entries[0]?.contentRect?.width||0);if(!width||Math.abs(width-analysisResizeWidth)<2)return;analysisResizeWidth=width;cancelAnimationFrame(analysisResizeFrame);analysisResizeFrame=requestAnimationFrame(()=>{if(document.querySelector('#view-analysis')?.classList.contains('active'))renderReadableAnalysis()})}).observe(frame)}
+setTimeout(()=>{if(document.querySelector('#view-analysis')?.classList.contains('active'))renderReadableAnalysis()},260);
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -19,6 +19,7 @@ const serVidaHandoffPath=path.join(dir,'app-ser-vida-handoff.js');
 const vidaNewViaPath=path.join(dir,'app-vida-new-via.js');
 const pilotEvaluationPath=path.join(dir,'app-pilot-evaluation.js');
 const navBadgesPath=path.join(dir,'app-nav-badges.js');
+const analysisUxPath=path.join(dir,'app-analysis-ux.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -36,6 +37,7 @@ const serVidaHandoff=fs.readFileSync(serVidaHandoffPath,'utf8');
 const vidaNewVia=fs.readFileSync(vidaNewViaPath,'utf8');
 const pilotEvaluation=fs.readFileSync(pilotEvaluationPath,'utf8');
 const navBadges=fs.readFileSync(navBadgesPath,'utf8');
+const analysisUx=fs.readFileSync(analysisUxPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -89,5 +91,6 @@ code += '\n\n/* Explicit staff SER→VIDA handoff uses the existing workflow com
 code += '\n\n/* Optional new VÍA remains an explicit staff-triggered new start point after VIDA, never an automatic fourth step. */\n'+vidaNewVia+'\n';
 code += '\n\n/* Project-level pilot evaluation is an aggregated learning entry, not a participant gate. */\n'+pilotEvaluation+'\n';
 code += '\n\n/* Navigation badges use distinct semantics: overview total, task severity, participant attention. */\n'+navBadges+'\n';
+code += '\n\n/* Analysis clarity layer adds explicit empty states, readable mobile chart identity and responsive redraw without data writes. */\n'+analysisUx+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);


### PR DESCRIPTION
Owner mobile feedback showed Analyse can be visually unclear and can look missing in some filter states.

This PR is presentation-only:
- adds an explicit DOM empty state when no measurements exist for the chosen metric/period;
- distinguishes that from selected participants having no measurements;
- shows per-participant point counts in selection chips;
- adds an external readable legend instead of relying on weak canvas color alone;
- uses stronger contrast, thicker lines/larger points plus dash patterns for identity beyond color;
- makes the chart responsive to resize/orientation changes and keeps mobile chart height bounded;
- reports metric/period/selected participant/datapoint context above the chart;
- explicitly does not fabricate/interpolate missing measurements.

Security/data boundary: no new queries, schema, writes, roles, RLS, AAL2, consent, intake or backend changes. The layer only renders the already RLS-scoped check-in data loaded by the portal.

Adds a dedicated source regression gate and keeps deterministic build integration.