### PR TITLE
Portal UX: return to originating task after form gate

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -114,3 +114,5 @@ jobs:
         run: node portal/analysis-clarity-smoke.mjs
       - name: Verify role-aware home presentation invariants
         run: node portal/role-home-smoke.mjs
+      - name: Verify task gate return-context invariants
+        run: node portal/task-gate-return-smoke.mjs

--- a/portal/app-return-context.js
+++ b/portal/app-return-context.js
@@ -1,0 +1,54 @@
+(()=>{
+'use strict';
+
+function taskReturnParams(){
+  const q=new URLSearchParams(location.search);
+  return{taskId:q.get('returnTask'),view:q.get('returnView')||'tasks'};
+}
+function decorateTaskFormLinks(){
+  if(!selectedTaskId)return;
+  document.querySelectorAll('#taskDialog a[href*="form-runner.html"]').forEach(a=>{
+    const u=new URL(a.getAttribute('href'),location.href);
+    u.searchParams.set('returnTask',selectedTaskId);
+    u.searchParams.set('returnView','tasks');
+    a.href=`${u.pathname}${u.search}`;
+  });
+}
+
+document.addEventListener('click',event=>{
+  const a=event.target.closest?.('#taskDialog a[href*="form-runner.html"]');
+  if(!a||!selectedTaskId)return;
+  const u=new URL(a.getAttribute('href'),location.href);
+  u.searchParams.set('returnTask',selectedTaskId);
+  u.searchParams.set('returnView','tasks');
+  a.href=`${u.pathname}${u.search}`;
+},true);
+
+const returnContextOpenTask=openTask;
+openTask=function(id){
+  returnContextOpenTask(id);
+  decorateTaskFormLinks();
+};
+
+let returnContextResumed=false;
+function resumeTaskContext(){
+  if(returnContextResumed)return;
+  const {taskId,view}=taskReturnParams();
+  if(!taskId||!(tasks||[]).some(t=>t.id===taskId))return;
+  returnContextResumed=true;
+  show(view==='tasks'?'tasks':'overview');
+  openTask(taskId);
+  const clean=new URL(location.href);
+  clean.searchParams.delete('returnTask');
+  clean.searchParams.delete('returnView');
+  history.replaceState({},'',`${clean.pathname}${clean.search}${clean.hash}`);
+}
+
+const returnContextRenderAll=renderAll;
+renderAll=function(){
+  returnContextRenderAll();
+  setTimeout(resumeTaskContext,0);
+};
+setTimeout(resumeTaskContext,220);
+
+})();

--- a/portal/build-app.mjs
+++ b/portal/build-app.mjs
@@ -21,6 +21,7 @@ const pilotEvaluationPath=path.join(dir,'app-pilot-evaluation.js');
 const navBadgesPath=path.join(dir,'app-nav-badges.js');
 const analysisUxPath=path.join(dir,'app-analysis-ux.js');
 const roleHomePath=path.join(dir,'app-role-home.js');
+const returnContextPath=path.join(dir,'app-return-context.js');
 const outPath=path.join(dir,'app.js');
 let code=fs.readFileSync(sourcePath,'utf8');
 const ops=fs.readFileSync(opsPath,'utf8');
@@ -40,6 +41,7 @@ const pilotEvaluation=fs.readFileSync(pilotEvaluationPath,'utf8');
 const navBadges=fs.readFileSync(navBadgesPath,'utf8');
 const analysisUx=fs.readFileSync(analysisUxPath,'utf8');
 const roleHome=fs.readFileSync(roleHomePath,'utf8');
+const returnContext=fs.readFileSync(returnContextPath,'utf8');
 
 function replaceOnce(label,needle,replacement){
  const first=code.indexOf(needle);if(first<0)throw new Error(`${label}: source pattern missing`);if(code.indexOf(needle,first+1)>=0)throw new Error(`${label}: source pattern is not unique`);code=code.replace(needle,replacement);
@@ -95,5 +97,6 @@ code += '\n\n/* Project-level pilot evaluation is an aggregated learning entry, 
 code += '\n\n/* Navigation badges use distinct semantics: overview total, task severity, participant attention. */\n'+navBadges+'\n';
 code += '\n\n/* Analysis clarity layer adds explicit empty states, readable mobile chart identity and responsive redraw without data writes. */\n'+analysisUx+'\n';
 code += '\n\n/* Role-aware home changes presentation only: participant journey, operational staff, and aggregate/project/evaluation lenses stay distinct without changing access. */\n'+roleHome+'\n';
+code += '\n\n/* Return context preserves task -> form gate -> same task continuity without adding backend state. */\n'+returnContext+'\n';
 fs.writeFileSync(outPath,code,'utf8');
 console.log(`Built ${path.relative(process.cwd(),outPath)} (${code.length} bytes)`);

--- a/portal/form-command-client.js
+++ b/portal/form-command-client.js
@@ -24,6 +24,31 @@ const FORM_ERROR_TEXT={
 };
 function formError(code){return FORM_ERROR_TEXT[code]||'Skjemaet kunne ikke lagres. Ingen alternativ direkte databasevei ble brukt.'}
 
+const returnQuery=new URLSearchParams(location.search);
+const returnTask=returnQuery.get('returnTask');
+const returnView=returnQuery.get('returnView')||'tasks';
+function returnTaskHref(){
+  if(!returnTask)return'./';
+  const q=new URLSearchParams({returnTask,returnView});
+  return`./?${q.toString()}`;
+}
+function ensureReturnTaskLink(){
+  if(!returnTask)return null;
+  let link=document.querySelector('#formReturnTask');
+  if(!link){
+    link=document.createElement('a');
+    link.id='formReturnTask';
+    link.className='ghost task-return-link';
+    link.href=returnTaskHref();
+    link.textContent='Tilbake til oppgaven';
+    document.querySelector('.runner-actions')?.prepend(link);
+  }
+  const portalLink=document.querySelector('.top-actions a.ghost[href="./"]');
+  if(portalLink){portalLink.href=returnTaskHref();portalLink.textContent='Tilbake til oppgaven'}
+  return link;
+}
+ensureReturnTaskLink();
+
 save=async function saveThroughCommand(status){
   if(!currentVersion||!contextOk())return;
   const participant=selectedParticipant(),pilot=selectedPilot(),org=orgId();
@@ -46,6 +71,10 @@ save=async function saveThroughCommand(status){
   const submission=data.submission;
   $('#formMessage').textContent=status==='SUBMITTED'?'Skjema fullført. Versjon, deltaker og pilotkontekst er bevart.':'Utkast lagret – du kan fortsette senere.';
   if(status==='DRAFT')currentDraft={id:submission.id};else currentDraft=null;
+  if(status==='SUBMITTED'){
+    const link=ensureReturnTaskLink();
+    if(link){link.className='primary task-return-link';link.textContent='Tilbake til oppgaven og se oppdatert status'}
+  }
   await loadSubmissions();
 };
 })();

--- a/portal/task-gate-return-smoke.mjs
+++ b/portal/task-gate-return-smoke.mjs
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const dir=path.dirname(fileURLToPath(import.meta.url));
+const app=fs.readFileSync(path.join(dir,'app-return-context.js'),'utf8');
+const form=fs.readFileSync(path.join(dir,'form-command-client.js'),'utf8');
+const build=fs.readFileSync(path.join(dir,'build-app.mjs'),'utf8');
+
+function ok(condition,message){if(!condition)throw new Error(message)}
+
+ok(app.includes("u.searchParams.set('returnTask',selectedTaskId)")&&app.includes("u.searchParams.set('returnView','tasks')"),'Task dialog form links must carry return context');
+ok(app.includes("openTask(taskId)")&&app.includes("show(view==='tasks'?'tasks':'overview')"),'Portal must resume the originating task after return');
+ok(app.includes("history.replaceState")&&app.includes("delete('returnTask')"),'Return parameters must be cleaned after resuming');
+ok(!app.includes('client.')&&!app.includes('.from(')&&!app.includes('functions.invoke')&&!app.includes('fetch('),'Task return context must remain presentation/navigation-only');
+ok(form.includes("client.functions.invoke('form-command'"),'Form save must continue through form-command');
+ok(form.includes("returnQuery.get('returnTask')")&&form.includes('Tilbake til oppgaven og se oppdatert status'),'Form runner must expose explicit return to the originating task');
+ok(!form.includes("client.from('form_submissions').insert")&&!form.includes("client.from('form_submissions').update"),'Command client must not add a direct form_submissions write fallback');
+ok(build.includes("app-return-context.js")&&build.indexOf("+returnContext+'\\n'")>build.indexOf("+roleHome+'\\n'"),'Return-context layer must be last in deterministic build');
+
+console.log('task gate return-context smoke: OK');


### PR DESCRIPTION
Preserves task context across task → form/gate → portal. Form links opened from a task carry returnTask/returnView, form-command client exposes an explicit return action without changing its secure write path, and the portal resumes the same task after return and cleans the URL. No new backend state, queries, grants, RLS or schema changes. Includes deterministic build integration and a dedicated smoke gate.